### PR TITLE
Add Preferences panel and persist editor defaults to localStorage

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,22 +1,29 @@
+import { useState } from 'react'
 import { Toolbar } from './Toolbar'
 import { TransportControls } from './TransportControls'
 import { PianoRoll } from './PianoRoll/PianoRoll'
+import { PreferencesPanel } from './PreferencesPanel'
 import { useKeyboardShortcuts } from '@/keymap/useKeyboardShortcuts'
 import { useAudioBridge } from '@/audio/useAudioBridge'
 
 
 export const App = () => {
+  const [preferencesOpen, setPreferencesOpen] = useState(false)
+
   useKeyboardShortcuts()
   useAudioBridge()
 
   return <div className="app">
     <header className="topbar">
-      <Toolbar />
+      <Toolbar onOpenPreferences={ () => setPreferencesOpen(true) } />
       <TransportControls />
     </header>
 
     <main className="editor">
       <PianoRoll />
+      {preferencesOpen &&
+        <PreferencesPanel onClose={ () => setPreferencesOpen(false) } />
+      }
     </main>
   </div>
 }

--- a/src/components/PreferencesPanel.tsx
+++ b/src/components/PreferencesPanel.tsx
@@ -1,0 +1,107 @@
+import { X } from 'lucide-react'
+import { useAppDispatch, useAppSelector } from '@/store/hooks'
+import {
+  setDefaultNoteDuration,
+  setDivision,
+  setPlayOnDraw,
+  setShowWaveform,
+  setSnapEnabled,
+  setTriplet,
+} from '@/store/slices/toolSlice'
+import { PPQ } from '@/domain/constants'
+import type { GridDivision } from '@/domain/types'
+
+
+interface PreferencesPanelProps {
+  onClose: () => void
+}
+
+const DIVISIONS: GridDivision[] = [ 1, 2, 4, 8, 16, 32 ]
+
+const DURATION_OPTIONS = [
+  { label: '1 bar', ticks: PPQ * 4 },
+  { label: '1/2 note', ticks: PPQ * 2 },
+  { label: '1/4 note', ticks: PPQ },
+  { label: '1/8 note', ticks: PPQ / 2 },
+  { label: '1/16 note', ticks: PPQ / 4 },
+  { label: '1/32 note', ticks: PPQ / 8 },
+]
+
+export const PreferencesPanel = ({ onClose }: PreferencesPanelProps) => {
+  const dispatch = useAppDispatch()
+  const tool     = useAppSelector(s => s.tool)
+
+  return <div className="preferences" role="dialog" aria-modal="false" aria-labelledby="preferences-title">
+    <div className="preferences__header">
+      <div>
+        <h2 id="preferences-title">Preferences</h2>
+        <p>Editor defaults are saved in this browser.</p>
+      </div>
+      <button type="button" className="tool-btn" aria-label="Close preferences" onClick={ onClose }>
+        <X size={ 16 } />
+      </button>
+    </div>
+
+    <section className="preferences__section" aria-label="Grid preferences">
+      <h3>Grid</h3>
+      <label className="preferences__row preferences__row--checkbox">
+        <input
+          type="checkbox"
+          checked={ tool.snapEnabled }
+          onChange={ e => dispatch(setSnapEnabled(e.target.checked)) }
+        />
+        <span>Snap edits to the grid</span>
+      </label>
+
+      <label className="preferences__row">
+        <span>Grid division</span>
+        <select
+          value={ tool.division }
+          onChange={ e => dispatch(setDivision(Number(e.target.value) as GridDivision)) }>
+          {DIVISIONS.map(d => <option key={ d } value={ d }>1/{d}</option>)}
+        </select>
+      </label>
+
+      <label className="preferences__row preferences__row--checkbox">
+        <input
+          type="checkbox"
+          checked={ tool.triplet }
+          onChange={ e => dispatch(setTriplet(e.target.checked)) }
+        />
+        <span>Use triplet grid</span>
+      </label>
+    </section>
+
+    <section className="preferences__section" aria-label="Drawing preferences">
+      <h3>Drawing</h3>
+      <label className="preferences__row">
+        <span>Default note length</span>
+        <select
+          value={ tool.defaultNoteDuration }
+          onChange={ e => dispatch(setDefaultNoteDuration(Number(e.target.value))) }>
+          {DURATION_OPTIONS.map(option =>
+            <option key={ option.ticks } value={ option.ticks }>{option.label}</option>
+          )}
+        </select>
+      </label>
+
+      <label className="preferences__row preferences__row--checkbox">
+        <input
+          type="checkbox"
+          checked={ tool.playOnDraw }
+          onChange={ e => dispatch(setPlayOnDraw(e.target.checked)) }
+        />
+        <span>Preview notes while drawing</span>
+      </label>
+
+      <label className="preferences__row preferences__row--checkbox">
+        <input
+          type="checkbox"
+          checked={ tool.showWaveform }
+          onChange={ e => dispatch(setShowWaveform(e.target.checked)) }
+        />
+        <span>Show waveform overlays on notes</span>
+      </label>
+    </section>
+  </div>
+}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -6,6 +6,7 @@ import {
   Magnet,
   AudioWaveform,
   Volume2,
+  Settings,
 } from 'lucide-react'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import {
@@ -28,7 +29,11 @@ const TOOLS: { kind: ToolKind; label: string; Icon: typeof Hand; hint: string }[
 
 const DIVISIONS: GridDivision[] = [ 1, 2, 4, 8, 16, 32 ]
 
-export const Toolbar = () => {
+interface ToolbarProps {
+  onOpenPreferences: () => void
+}
+
+export const Toolbar = ({ onOpenPreferences }: ToolbarProps) => {
   const dispatch     = useAppDispatch()
   const active       = useAppSelector(s => s.tool.active)
   const snap         = useAppSelector(s => s.tool.snapEnabled)
@@ -86,6 +91,15 @@ export const Toolbar = () => {
     </div>
 
     <div className="toolbar__group">
+      <button
+        type="button"
+        title="Open preferences"
+        aria-label="Open preferences"
+        className="tool-btn"
+        onClick={ onOpenPreferences }>
+        <Settings size={ 16 } />
+      </button>
+
       <button
         type="button"
         title="Waveform overlay on notes"

--- a/src/index.css
+++ b/src/index.css
@@ -147,3 +147,90 @@ body {
   height: 100%;
   touch-action: none;
 }
+
+.preferences {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 10;
+  width: min(360px, calc(100vw - 24px));
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: rgba(22, 23, 27, 0.98);
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.35);
+}
+
+.preferences__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.preferences h2,
+.preferences h3,
+.preferences p {
+  margin: 0;
+}
+
+.preferences h2 {
+  font-size: 16px;
+}
+
+.preferences h3 {
+  margin-bottom: 10px;
+  font-size: 12px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.preferences p {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.preferences__section {
+  display: grid;
+  gap: 10px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+}
+
+.preferences__section + .preferences__section {
+  margin-top: 14px;
+}
+
+.preferences__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.preferences__row--checkbox {
+  justify-content: flex-start;
+  gap: 10px;
+}
+
+.preferences__row select {
+  height: 30px;
+  min-width: 120px;
+  background: #23252b;
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0 8px;
+  font-size: 12px;
+}
+
+.preferences__row input[type='checkbox'] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent);
+}

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -1,0 +1,81 @@
+import type { Middleware } from '@reduxjs/toolkit'
+import { initialToolState, type ToolState } from './slices/toolSlice'
+import type { GridDivision } from '@/domain/types'
+
+const STORAGE_KEY = 'tween-midi-editor.preferences'
+const DIVISIONS: GridDivision[] = [ 1, 2, 4, 8, 16, 32 ]
+
+type PersistedPreferences = Pick<
+  ToolState,
+  'snapEnabled' | 'division' | 'triplet' | 'defaultNoteDuration' | 'showWaveform' | 'playOnDraw'
+>
+
+const isGridDivision = (value: unknown): value is GridDivision =>
+  typeof value === 'number' && DIVISIONS.includes(value as GridDivision)
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+export const loadToolPreferences = (): Partial<ToolState> => {
+  if (typeof window === 'undefined')
+    return {}
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw)
+      return {}
+
+    const parsed = JSON.parse(raw) as unknown
+    if (!isRecord(parsed))
+      return {}
+
+    const preferences: Partial<ToolState> = {}
+
+    if (typeof parsed.snapEnabled === 'boolean')
+      preferences.snapEnabled = parsed.snapEnabled
+    if (isGridDivision(parsed.division))
+      preferences.division = parsed.division
+    if (typeof parsed.triplet === 'boolean')
+      preferences.triplet = parsed.triplet
+    if (typeof parsed.defaultNoteDuration === 'number' && Number.isFinite(parsed.defaultNoteDuration))
+      preferences.defaultNoteDuration = Math.max(1, Math.round(parsed.defaultNoteDuration))
+    if (typeof parsed.showWaveform === 'boolean')
+      preferences.showWaveform = parsed.showWaveform
+    if (typeof parsed.playOnDraw === 'boolean')
+      preferences.playOnDraw = parsed.playOnDraw
+
+    return preferences
+  } catch {
+    return {}
+  }
+}
+
+const selectPersistedPreferences = (tool: ToolState): PersistedPreferences => ({
+  snapEnabled:         tool.snapEnabled,
+  division:            tool.division,
+  triplet:             tool.triplet,
+  defaultNoteDuration: tool.defaultNoteDuration,
+  showWaveform:        tool.showWaveform,
+  playOnDraw:          tool.playOnDraw,
+})
+
+export const persistedToolState: ToolState = {
+  ...initialToolState,
+  ...loadToolPreferences(),
+}
+
+export const preferencesMiddleware: Middleware = storeApi => next => action => {
+  const result = next(action)
+
+  if (typeof window === 'undefined')
+    return result
+
+  try {
+    const state = storeApi.getState() as { tool: ToolState }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(selectPersistedPreferences(state.tool)))
+  } catch {
+    // Persistence is best-effort: private browsing and storage quotas should not break editing.
+  }
+
+  return result
+}

--- a/src/store/slices/toolSlice.ts
+++ b/src/store/slices/toolSlice.ts
@@ -4,7 +4,7 @@ import { DEFAULT_DIVISION, DEFAULT_NOTE_DURATION } from '@/domain/constants'
 import type { GridDivision, Ticks, ToolKind } from '@/domain/types'
 
 
-interface ToolState {
+export interface ToolState {
   active:              ToolKind
   snapEnabled:         boolean
   division:            GridDivision
@@ -14,7 +14,7 @@ interface ToolState {
   playOnDraw:          boolean
 }
 
-const initialState: ToolState = {
+export const initialToolState: ToolState = {
   active:              'select',
   snapEnabled:         true,
   division:            DEFAULT_DIVISION,
@@ -27,14 +27,17 @@ const initialState: ToolState = {
 const DIVISIONS: GridDivision[] = [ 1, 2, 4, 8, 16, 32 ]
 
 const toolSlice = createSlice({
-  name:     'tool',
-  initialState,
-  reducers: {
+  name:         'tool',
+  initialState: initialToolState,
+  reducers:     {
     setTool: (state, action: PayloadAction<ToolKind>) => {
       state.active = action.payload
     },
     toggleSnap: state => {
       state.snapEnabled = !state.snapEnabled
+    },
+    setSnapEnabled: (state, action: PayloadAction<boolean>) => {
+      state.snapEnabled = action.payload
     },
     setDivision: (state, action: PayloadAction<GridDivision>) => {
       state.division = action.payload
@@ -56,6 +59,9 @@ const toolSlice = createSlice({
     toggleTriplet: state => {
       state.triplet = !state.triplet
     },
+    setTriplet: (state, action: PayloadAction<boolean>) => {
+      state.triplet = action.payload
+    },
     setDefaultNoteDuration: (state, action: PayloadAction<Ticks>) => {
       state.defaultNoteDuration = Math.max(1, action.payload)
     },
@@ -64,10 +70,16 @@ const toolSlice = createSlice({
     toggleWaveform: state => {
       state.showWaveform = !state.showWaveform
     },
+    setShowWaveform: (state, action: PayloadAction<boolean>) => {
+      state.showWaveform = action.payload
+    },
 
     /** Toggle audible preview of notes as they are drawn. */
     togglePlayOnDraw: state => {
       state.playOnDraw = !state.playOnDraw
+    },
+    setPlayOnDraw: (state, action: PayloadAction<boolean>) => {
+      state.playOnDraw = action.payload
     },
   },
 })
@@ -75,13 +87,17 @@ const toolSlice = createSlice({
 export const {
   setTool,
   toggleSnap,
+  setSnapEnabled,
   setDivision,
   finerGrid,
   coarserGrid,
   toggleTriplet,
+  setTriplet,
   setDefaultNoteDuration,
   toggleWaveform,
+  setShowWaveform,
   togglePlayOnDraw,
+  setPlayOnDraw,
 } = toolSlice.actions
 
 export default toolSlice.reducer

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -5,6 +5,7 @@ import selectionReducer from './slices/selectionSlice'
 import toolReducer from './slices/toolSlice'
 import transportReducer from './slices/transportSlice'
 import viewportReducer from './slices/viewportSlice'
+import { persistedToolState, preferencesMiddleware } from './persistence'
 
 // Only the note data is historized for undo/redo. Transport position updates are
 // dispatched continuously by the audio engine, so they must never create history.
@@ -23,6 +24,10 @@ const rootReducer = combineReducers({
 
 export const store = configureStore({
   reducer: rootReducer,
+  preloadedState: {
+    tool: persistedToolState,
+  },
+  middleware: getDefaultMiddleware => getDefaultMiddleware().concat(preferencesMiddleware),
 })
 
 export type RootState = ReturnType<typeof store.getState>


### PR DESCRIPTION
### Motivation
- Provide a UI for editing editor defaults (grid, drawing, preview) and make those preferences survive page reloads.
- Expose controls for waveform/play-preview and grid options from the toolbar into a dedicated preferences dialog.
- Make preference changes handled via the Redux `tool` slice and persist them to `localStorage` for a consistent editor experience.

### Description
- Add a new `PreferencesPanel` component at `src/components/PreferencesPanel.tsx` with controls for grid division, snap, triplet grid, default note length, play-on-draw, and waveform overlay and a close button wired to the parent.
- Wire the panel into the UI by adding a `Settings` button in `Toolbar` (prop `onOpenPreferences`) and tracking `preferencesOpen` in `App.tsx` to mount/unmount the panel.
- Add CSS for the preferences dialog in `src/index.css` to style the dialog and its fields.
- Introduce persistence support in `src/store/persistence.ts` that loads saved preferences (`loadToolPreferences`), exposes `persistedToolState`, and a `preferencesMiddleware` that writes selected `tool` fields to `localStorage` under `tween-midi-editor.preferences`.
- Update the `tool` slice (`src/store/slices/toolSlice.ts`) to export `initialToolState`/`ToolState`, add explicit setter actions (`setSnapEnabled`, `setTriplet`, `setShowWaveform`, `setPlayOnDraw`) while keeping existing toggle actions, and use `initialToolState` as the slice initial state.
- Configure the store (`src/store/store.ts`) to preload `tool` state from `persistedToolState` and append the `preferencesMiddleware` to the middleware chain.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4dd6c4996c8324ad3f6d1c8257a67f)