### PR TITLE
Touch gestures, scroll zoom, Ableton-style loop & clip-end markers, MIDI save/load, merged select tool

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: verify
+description: Build, launch, and drive the piano roll app to verify changes end-to-end (dev server + Playwright with the preinstalled Chromium).
+---
+
+# Verifying changes in tween-midi-editor
+
+## Build & launch
+
+```bash
+ELECTRON_SKIP_BINARY_DOWNLOAD=1 npm ci   # plain `npm ci` fails in sandboxes that block the Electron binary CDN
+npm run dev -- --port 5199 --strictPort  # Vite dev server
+```
+
+## Drive it (Playwright)
+
+Use the preinstalled Chromium — do NOT run `playwright install`:
+
+```js
+import { chromium } from '@playwright/test'
+const browser = await chromium.launch({ executablePath: '/opt/pw-browsers/chromium' })
+```
+
+Run scripts from a directory that can resolve `@playwright/test` (the repo root,
+or symlink `node_modules` next to the script).
+
+Flows worth driving:
+- The whole UI is one `<canvas>` (`canvas.piano-roll__canvas`); assert via
+  screenshots, not DOM. Toolbar buttons have `aria-label`s (e.g. "Save MIDI file").
+- Draw notes: press `b`, click the grid; `Escape` returns to select.
+- Marquee: with select tool, mouse-drag on empty grid space.
+- Wheel zoom: `page.mouse.wheel(0, -120)` over the canvas (plain wheel = zoom X).
+- Ruler (top 28px of the canvas): lower half click = seek; upper half = loop
+  brace / clip-end marker drags.
+- Touch/pinch: Playwright has no multi-touch API — use a CDP session and
+  `Input.dispatchTouchEvent` with two `touchPoints`.
+- Export: click "Save MIDI file", await the `download` event.
+- Import: click "Open MIDI file", await the `filechooser` event, `setFiles(...)`.
+
+## Gotchas
+
+- A `/favicon.ico` 404 console error is pre-existing noise, not a regression.
+- Audio (`AudioContext`) is silent headless; playback state still updates the
+  playhead, which is visible in screenshots.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -31,14 +31,17 @@ source of truth for scope; keep it updated as features land.
 - **selectionSlice** — `{ selectedIds }` with select/toggle/add/set/clear.
 - **toolSlice** — active tool, grid snap, division, triplet, default note duration,
   `showWaveform`, `playOnDraw`.
-- **transportSlice** — `isPlaying`, `bpm`, `positionTicks`, `loop`, `timeSignature`,
-  `metronome`.
+- **transportSlice** — `isPlaying`, `bpm`, `positionTicks`, `loop`, `clipEndTicks`
+  (the Ableton-style clip end marker; playback stops there when looping is off),
+  `timeSignature`, `metronome`.
 - **viewportSlice** — `pxPerTick`, `rowHeight`, `scrollTicks`, `scrollPitch`, size;
   zoom-to-cursor on both axes, pan.
+- **projectSlice** — `fileName`, `dirty` (set by `projectMiddleware` on
+  content-changing actions, cleared on save/load).
 
 Cross-slice operations (delete, select-all, copy/cut/paste, duplicate, nudge,
 transpose, undo/redo) are **thunks** in `src/thunks/editingThunks.ts` — never
-inside reducers.
+inside reducers. MIDI import/export live in `src/thunks/projectThunks.ts`.
 
 ### 2.3 View layer (`src/view`)
 - `coords.ts` — pure musical↔pixel transforms (`tickToX`, `xToTick`, `pitchToY`,
@@ -54,15 +57,25 @@ inside reducers.
   **single action on pointer-up**, so the store never churns per frame.
 
 ### 2.5 Tools, input & shortcuts
-- Tools: **select** (move/resize/multi-select), **pan**, **draw** (pencil add/remove),
-  **marquee**.
-- Icon toolbar + transport controls (play/stop, BPM, loop) + grid/snap/triplet +
-  waveform & play-on-draw toggles.
+- Tools: **select** (move/resize/multi-select; dragging empty space rubber-band
+  selects, Ableton-style), **draw** (pencil add/remove), **pan**.
+- Icon toolbar (incl. Open/Save MIDI + file name/dirty indicator) + transport
+  controls (play/stop, BPM, loop) + grid/snap/triplet + waveform & play-on-draw
+  toggles.
 - Ableton-grounded keymap (`src/keymap`): Draw `B`, Play/Stop `Space`, Delete,
   Select-all `Ctrl/Cmd+A`, Copy/Cut/Paste, Duplicate `Ctrl/Cmd+D`, Undo/Redo,
   nudge `Ctrl/Cmd+←/→`, transpose `↑/↓` (octave with `Shift`), grid `Ctrl/Cmd+1/2/3/4`,
-  loop `Ctrl/Cmd+L`, zoom `+/-`. Mouse wheel scrolls; `Ctrl/Cmd+wheel` zooms X;
-  `Alt+wheel` zooms Y.
+  loop `Ctrl/Cmd+L`, zoom `+/-`, Open `Ctrl/Cmd+O`, Save `Ctrl/Cmd+S`.
+- Wheel (native non-passive listener): plain wheel **zooms X** at the cursor;
+  `Ctrl/Cmd+wheel` zooms X (covers trackpad pinch); `Alt+wheel` zooms Y;
+  `Shift+wheel` pans; dominant horizontal deltas pan the timeline
+  (`interactions/wheelIntent.ts`).
+- **Touch**: one finger drives the active tool; two fingers pinch-zoom per axis
+  and pan (`interactions/pinch.ts` + the `usePianoRollInteractions` router,
+  which owns pointer routing by region: ruler / keyboard / grid).
+- **Ruler**: lower band click/drag seeks (scrubs); upper band hosts the
+  draggable loop brace (body moves, edges resize) and the clip-end marker
+  (`src/view/rulerHitTest.ts`, wider grab tolerance for touch).
 
 ### 2.6 Audio (`src/audio`)
 - `AudioEngine` owns the `AudioContext` and a lookahead scheduler (Chris Wilson
@@ -89,16 +102,15 @@ inside reducers.
 > separation: new data lives in slices, mutated only via actions/thunks; the canvas
 > and panels stay presentational.
 
-### 3.1 MIDI file load & save
-- **Import**: parse Standard MIDI Files (SMF type 0/1) into the domain model.
-  Map note-on/note-off pairs to `Note` (ticks scaled to project PPQ), import tempo
-  and time-signature meta events into `transportSlice`. Use a small parser
-  (e.g. `@tonejs/midi` or a hand-rolled reader) behind a `midi/io` module that emits
-  plain domain objects — the store never sees raw MIDI bytes.
-- **Export**: serialize notes + tempo/meta back to SMF; trigger a download
-  (browser) or native save dialog (Electron, behind a capability check).
-- New slice/thunks: `projectSlice` (file name, dirty flag), `importMidi`/`exportMidi`
-  thunks. Drag-and-drop a `.mid` file onto the editor to import.
+### 3.1 MIDI file load & save — ✅ implemented
+Shipped as designed (see §2.2/§2.5): a hand-rolled SMF reader/writer in
+`src/midi/` (`smfParse.ts` handles type 0/1, running status, PPQ rescaling;
+`smfEncode.ts` writes type 0) emits plain domain objects — the store never sees
+raw MIDI bytes. `projectSlice` (file name, dirty flag) plus
+`importMidiData`/`importMidiFile`/`exportMidi` thunks; toolbar buttons,
+`Ctrl/Cmd+O`/`Ctrl/Cmd+S`, and drag-and-drop of `.mid` files onto the window.
+Still open: native save dialog in the Electron wrapper (browser download is
+used everywhere today).
 
 ### 3.2 Controllers, automation & messages
 - **Per-note expression**: velocity already exists; add an editable **velocity lane**

--- a/src/audio/AudioEngine.ts
+++ b/src/audio/AudioEngine.ts
@@ -11,7 +11,9 @@ export interface EngineProviders {
   getNotes:   () => Note[]
   getBpm:     () => number
   getLoop:    () => LoopRegion
+  getClipEnd: () => Ticks
   onPosition: (ticks: Ticks) => void
+  onClipEnd:  () => void
 }
 
 /**
@@ -132,12 +134,24 @@ export class AudioEngine {
       this.playStartTick +
       secondsToTicks(now + SCHEDULE_AHEAD_SEC - this.audioStartTime, bpm)
 
+    // With looping off, playback ends at the clip end marker. Starting at or
+    // past the marker plays freely instead of stopping instantly.
+    const clipEnd    = this.providers.getClipEnd()
+    const endsAtClip = !loop.enabled && this.playStartTick < clipEnd
+
+    if (endsAtClip && this.currentTick() >= clipEnd) {
+      this.providers.onClipEnd()
+      return
+    }
+
     let windowEnd = horizonTick
     let wrap      = false
     if (loop.enabled && horizonTick >= loop.endTicks) {
       windowEnd = loop.endTicks
       wrap = true
     }
+    else if (endsAtClip)
+      windowEnd = Math.min(horizonTick, clipEnd)
 
     this.scheduleRange(notes, this.cursorTick, windowEnd, bpm)
 

--- a/src/audio/transportBridge.ts
+++ b/src/audio/transportBridge.ts
@@ -1,5 +1,5 @@
 import type { AppStore } from '@/store/store'
-import { setPosition } from '@/store/slices/transportSlice'
+import { seek, setPosition, stop } from '@/store/slices/transportSlice'
 import { selectAllNotes } from '@/store/selectors/noteSelectors'
 import { AudioEngine } from './AudioEngine'
 import { setActiveEngine } from './engine'
@@ -16,9 +16,14 @@ export function createAudioBridge (store: AppStore) {
     getNotes:   () => selectAllNotes(store.getState()),
     getBpm:     () => store.getState().transport.bpm,
     getLoop:    () => store.getState().transport.loop,
+    getClipEnd: () => store.getState().transport.clipEndTicks,
     onPosition: ticks => {
       lastEnginePos = ticks
       store.dispatch(setPosition(ticks))
+    },
+    onClipEnd: () => {
+      store.dispatch(stop())
+      store.dispatch(seek(0))
     },
   })
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,13 +5,15 @@ import { PianoRoll } from './PianoRoll/PianoRoll'
 import { PreferencesPanel } from './PreferencesPanel'
 import { useKeyboardShortcuts } from '@/keymap/useKeyboardShortcuts'
 import { useAudioBridge } from '@/audio/useAudioBridge'
+import { useMidiDrop } from './useMidiDrop'
 
 
 export const App = () => {
-  const [preferencesOpen, setPreferencesOpen] = useState(false)
+  const [ preferencesOpen, setPreferencesOpen ] = useState(false)
 
   useKeyboardShortcuts()
   useAudioBridge()
+  useMidiDrop()
 
   return <div className="app">
     <header className="topbar">
@@ -21,8 +23,8 @@ export const App = () => {
 
     <main className="editor">
       <PianoRoll />
-      {preferencesOpen &&
-        <PreferencesPanel onClose={ () => setPreferencesOpen(false) } />
+
+      {preferencesOpen ? <PreferencesPanel onClose={ () => setPreferencesOpen(false) } /> : null
       }
     </main>
   </div>

--- a/src/components/PianoRoll/PianoRoll.tsx
+++ b/src/components/PianoRoll/PianoRoll.tsx
@@ -2,15 +2,14 @@ import { useEffect, useRef } from 'react'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import { setViewportSize } from '@/store/slices/viewportSlice'
 import { useCanvasRenderer } from './useCanvasRenderer'
-import { useToolInteractions } from './interactions/useToolInteractions'
+import { usePianoRollInteractions } from './interactions/usePianoRollInteractions'
 import type { Draft } from './interactions/types'
 
 
 const TOOL_CURSOR: Record<string, string> = {
-  select:  'default',
-  pan:     'grab',
-  draw:    'crosshair',
-  marquee: 'crosshair',
+  select: 'default',
+  pan:    'grab',
+  draw:   'crosshair',
 }
 
 export const PianoRoll = () => {
@@ -21,7 +20,7 @@ export const PianoRoll = () => {
   const tool         = useAppSelector(s => s.tool.active)
 
   const requestRedraw = useCanvasRenderer(canvasRef, draftRef)
-  const handlers      = useToolInteractions(draftRef, requestRedraw)
+  const handlers      = usePianoRollInteractions(canvasRef, draftRef, requestRedraw)
 
   // Keep the viewport size in sync with the container.
   useEffect(() => {
@@ -46,7 +45,6 @@ export const PianoRoll = () => {
       onPointerDown={ handlers.onPointerDown }
       onPointerMove={ handlers.onPointerMove }
       onPointerUp={ handlers.onPointerUp }
-      onPointerCancel={ handlers.onPointerUp }
-      onWheel={ handlers.onWheel } />
+      onPointerCancel={ handlers.onPointerUp } />
   </div>
 }

--- a/src/components/PianoRoll/interactions/pinch.test.ts
+++ b/src/components/PianoRoll/interactions/pinch.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { pinchDelta } from './pinch'
+import type { PinchPair } from './pinch'
+
+
+const pair = (ax: number, ay: number, bx: number, by: number): PinchPair => ({
+  a: { x: ax, y: ay },
+  b: { x: bx, y: by },
+})
+
+describe('pinchDelta', () => {
+  it('doubling the horizontal spread doubles factorX', () => {
+    const d = pinchDelta(pair(100, 0, 200, 0), pair(50, 0, 250, 0))
+    expect(d.factorX).toBeCloseTo(2)
+    expect(d.factorY).toBe(1) // vertical spread stays in the dead zone
+  })
+
+  it('halving the vertical spread gives factorY 0.5', () => {
+    const d = pinchDelta(pair(0, 100, 0, 300), pair(0, 150, 0, 250))
+    expect(d.factorY).toBeCloseTo(0.5)
+    expect(d.factorX).toBe(1)
+  })
+
+  it('applies a dead zone when fingers are nearly stacked on an axis', () => {
+    // 10px -> 20px horizontal spread is a 2x ratio but under the threshold.
+    const d = pinchDelta(pair(100, 0, 110, 0), pair(100, 0, 120, 0))
+    expect(d.factorX).toBe(1)
+  })
+
+  it('clamps a single event factor to at most 2 and at least 0.5', () => {
+    const explode = pinchDelta(pair(0, 0, 30, 0), pair(0, 0, 300, 0))
+    expect(explode.factorX).toBe(2)
+
+    const collapse = pinchDelta(pair(0, 0, 300, 0), pair(0, 0, 30, 0))
+    expect(collapse.factorX).toBe(0.5)
+  })
+
+  it('reports centroid and its movement', () => {
+    const d = pinchDelta(pair(0, 0, 100, 100), pair(20, 10, 120, 110))
+    expect(d.centroid).toEqual({ x: 70, y: 60 })
+    expect(d.dxPx).toBeCloseTo(20)
+    expect(d.dyPx).toBeCloseTo(10)
+  })
+
+  it('is symmetric under swapping the two pointers', () => {
+    const d1 = pinchDelta(pair(100, 0, 200, 50), pair(80, 0, 220, 60))
+    const d2 = pinchDelta(pair(200, 50, 100, 0), pair(220, 60, 80, 0))
+    expect(d1.factorX).toBeCloseTo(d2.factorX)
+    expect(d1.factorY).toBeCloseTo(d2.factorY)
+    expect(d1.dxPx).toBeCloseTo(d2.dxPx)
+    expect(d1.dyPx).toBeCloseTo(d2.dyPx)
+  })
+})

--- a/src/components/PianoRoll/interactions/pinch.ts
+++ b/src/components/PianoRoll/interactions/pinch.ts
@@ -1,0 +1,50 @@
+// Pure two-finger pinch math. No React, no DOM, no store.
+
+import { PINCH_MIN_SPREAD_PX } from '@/domain/constants'
+
+
+export interface PointerPt {
+  x: number
+  y: number
+}
+
+export interface PinchPair {
+  a: PointerPt
+  b: PointerPt
+}
+
+export interface PinchDelta {
+  factorX:  number // ratio of horizontal spreads (1 = no zoom)
+  factorY:  number // ratio of vertical spreads
+  centroid: PointerPt // next centroid
+  dxPx:     number // centroid movement prev -> next
+  dyPx:     number
+}
+
+// Bounds a single event's zoom jump; absolute zoom limits live in the reducers.
+const clampFactor = (f: number): number => Math.max(0.5, Math.min(2, f))
+
+const axisFactor = (prevSpread: number, nextSpread: number): number => {
+  // Dead zone: fingers nearly stacked on this axis carry no zoom intent and
+  // would otherwise produce divide-by-near-zero blowups.
+  if (Math.max(prevSpread, nextSpread) < PINCH_MIN_SPREAD_PX)
+    return 1
+  return clampFactor(nextSpread / Math.max(1, prevSpread))
+}
+
+export function pinchDelta (prev: PinchPair, next: PinchPair): PinchDelta {
+  const factorX = axisFactor(Math.abs(prev.a.x - prev.b.x), Math.abs(next.a.x - next.b.x))
+  const factorY = axisFactor(Math.abs(prev.a.y - prev.b.y), Math.abs(next.a.y - next.b.y))
+
+  const prevCx   = (prev.a.x + prev.b.x) / 2
+  const prevCy   = (prev.a.y + prev.b.y) / 2
+  const centroid = { x: (next.a.x + next.b.x) / 2, y: (next.a.y + next.b.y) / 2 }
+
+  return {
+    factorX,
+    factorY,
+    centroid,
+    dxPx: centroid.x - prevCx,
+    dyPx: centroid.y - prevCy,
+  }
+}

--- a/src/components/PianoRoll/interactions/usePianoRollInteractions.ts
+++ b/src/components/PianoRoll/interactions/usePianoRollInteractions.ts
@@ -1,0 +1,239 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useAppStore } from '@/store/hooks'
+import { selectViewport } from '@/store/selectors/viewportSelectors'
+import { panBy, zoomX, zoomY } from '@/store/slices/viewportSlice'
+import { xToTick, yToPitch, yToPitchLane } from '@/view/coords'
+import { playPreview } from '@/audio/engine'
+import type { Draft } from './types'
+import { pinchDelta } from './pinch'
+import type { PinchPair, PointerPt } from './pinch'
+import { useRulerInteractions } from './useRulerInteractions'
+import { useToolInteractions } from './useToolInteractions'
+import { localPoint } from './utils'
+import { resolveWheelIntent } from './wheelIntent'
+
+
+type Mode = 'idle' | 'grid' | 'ruler' | 'pinch'
+
+interface PinchState {
+  ids:  [ number, number ]
+  prev: PinchPair
+}
+
+/**
+ * Routes pointer input by region (ruler / keyboard / note grid) and pointer
+ * count: the first pointer drives a region gesture, a second pointer cancels
+ * it and starts a two-finger pinch (zoom + pan). Owns pointer capture and the
+ * native non-passive wheel listener (React's onWheel is passive, so it cannot
+ * preventDefault browser page-zoom on ctrl+wheel).
+ */
+export function usePianoRollInteractions (
+  canvasRef: React.MutableRefObject<HTMLCanvasElement | null>,
+  draftRef: React.MutableRefObject<Draft>,
+  requestRedraw: () => void,
+) {
+  const store = useAppStore()
+  const grid  = useToolInteractions(draftRef, requestRedraw)
+  const ruler = useRulerInteractions(requestRedraw)
+
+  const pointers = useRef(new Map<number, PointerPt>())
+  const mode     = useRef<Mode>('idle')
+  const pinch    = useRef<PinchState | null>(null)
+
+  const cancelActiveGesture = useCallback(
+    () => {
+      switch (mode.current) {
+        case 'grid': {
+          grid.cancel()
+          break
+        }
+        case 'ruler': {
+          ruler.cancel()
+          break
+        }
+      }
+    },
+    [ grid, ruler ],
+  )
+
+  const beginPinch = useCallback(
+    () => {
+      const entries = [ ...pointers.current.entries() ]
+      if (entries.length < 2)
+        return
+
+      cancelActiveGesture()
+
+      const [[ idA, a ], [ idB, b ]] = entries
+      pinch.current                  = { ids: [ idA, idB ], prev: { a: { ...a }, b: { ...b }}}
+      mode.current                   = 'pinch'
+    },
+    [ cancelActiveGesture ],
+  )
+
+  const movePinch = useCallback(
+    () => {
+      const p = pinch.current
+      if (!p)
+        return
+
+      const a = pointers.current.get(p.ids[0])
+      const b = pointers.current.get(p.ids[1])
+      if (!a || !b)
+        return
+
+      const next  = { a: { ...a }, b: { ...b }}
+      const delta = pinchDelta(p.prev, next)
+      p.prev      = next
+
+      // Anchor-stable zooms first, then translate with the centroid. The
+      // viewport is re-read between dispatches so each anchor is exact.
+      if (delta.factorX !== 1) {
+        const vp = selectViewport(store.getState())
+        store.dispatch(zoomX({ factor: delta.factorX, anchorTicks: xToTick(delta.centroid.x, vp) }))
+      }
+      if (delta.factorY !== 1) {
+        const vp = selectViewport(store.getState())
+        store.dispatch(zoomY({ factor: delta.factorY, anchorPitch: yToPitch(delta.centroid.y, vp) }))
+      }
+      if (delta.dxPx !== 0 || delta.dyPx !== 0)
+        store.dispatch(panBy({ dxPx: delta.dxPx, dyPx: delta.dyPx }))
+      requestRedraw()
+    },
+    [ store, requestRedraw ],
+  )
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLCanvasElement>) => {
+      const [ px, py ] = localPoint(e)
+      pointers.current.set(e.pointerId, { x: px, y: py })
+      e.currentTarget.setPointerCapture(e.pointerId)
+
+      if (pointers.current.size === 2) {
+        beginPinch()
+        return
+      }
+      if (pointers.current.size > 2)
+        return
+
+      const vp = selectViewport(store.getState())
+
+      // Left keyboard column auditions the pitch under the pointer.
+      if (px < vp.keyboardWidth) {
+        if (py >= vp.rulerHeight)
+          playPreview(yToPitchLane(py, vp), 100)
+        return
+      }
+      if (py < vp.rulerHeight) {
+        mode.current = 'ruler'
+        ruler.onPointerDown(e)
+        return
+      }
+      mode.current = 'grid'
+      grid.onPointerDown(e)
+    },
+    [ store, grid, ruler, beginPinch ],
+  )
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLCanvasElement>) => {
+      const tracked = pointers.current.get(e.pointerId)
+      if (tracked) {
+        const [ px, py ] = localPoint(e)
+        tracked.x        = px
+        tracked.y        = py
+      }
+
+      switch (mode.current) {
+        case 'grid': {
+          grid.onPointerMove(e)
+          break
+        }
+        case 'ruler': {
+          ruler.onPointerMove(e)
+          break
+        }
+        case 'pinch': {
+          if (tracked && pinch.current?.ids.includes(e.pointerId))
+            movePinch()
+          break
+        }
+      }
+    },
+    [ grid, ruler, movePinch ],
+  )
+
+  const onPointerUp = useCallback(
+    (e: React.PointerEvent<HTMLCanvasElement>) => {
+      pointers.current.delete(e.pointerId)
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId)
+      }
+      catch {
+        // ignore: capture may already be gone (e.g. pointercancel)
+      }
+
+      switch (mode.current) {
+        case 'grid': {
+          grid.onPointerUp()
+          mode.current = 'idle'
+          break
+        }
+        case 'ruler': {
+          ruler.onPointerUp()
+          mode.current = 'idle'
+          break
+        }
+        case 'pinch': {
+          if (pinch.current?.ids.includes(e.pointerId)) {
+            // The remaining finger stays inert until lifted and re-pressed.
+            pinch.current = null
+            mode.current  = 'idle'
+          }
+          break
+        }
+      }
+    },
+    [ grid, ruler ],
+  )
+
+  // Native non-passive wheel listener: scroll zooms, modifiers pan/zoom-Y.
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas)
+      return
+
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault()
+
+      const vp     = selectViewport(store.getState())
+      const rect   = canvas.getBoundingClientRect()
+      const px     = e.clientX - rect.left
+      const py     = e.clientY - rect.top
+      const intent = resolveWheelIntent(e)
+
+      switch (intent.kind) {
+        case 'zoomX': {
+          store.dispatch(zoomX({ factor: intent.factor, anchorTicks: xToTick(px, vp) }))
+          break
+        }
+        case 'zoomY': {
+          store.dispatch(zoomY({ factor: intent.factor, anchorPitch: yToPitch(py, vp) }))
+          break
+        }
+        case 'pan': {
+          store.dispatch(panBy({ dxPx: intent.dxPx, dyPx: intent.dyPx }))
+          break
+        }
+      }
+    }
+
+    canvas.addEventListener('wheel', onWheel, { passive: false })
+    return () => canvas.removeEventListener('wheel', onWheel)
+  }, [ canvasRef, store ])
+
+  return useMemo(
+    () => ({ onPointerDown, onPointerMove, onPointerUp }),
+    [ onPointerDown, onPointerMove, onPointerUp ],
+  )
+}

--- a/src/components/PianoRoll/interactions/useRulerInteractions.ts
+++ b/src/components/PianoRoll/interactions/useRulerInteractions.ts
@@ -1,0 +1,117 @@
+import { useCallback, useMemo, useRef } from 'react'
+import { useAppStore } from '@/store/hooks'
+import { selectViewport } from '@/store/selectors/viewportSelectors'
+import { seek, setClipEnd, setLoop } from '@/store/slices/transportSlice'
+import { divisionTicks, snapTicks } from '@/domain/time'
+import { xToTick } from '@/view/coords'
+import { rulerHitTest } from '@/view/rulerHitTest'
+import type { RulerHit } from '@/view/rulerHitTest'
+import { localPoint } from './utils'
+
+
+interface RulerGesture {
+  hit:             RulerHit
+  grabOffsetTicks: number // tick distance from pointer to loop start (body drag)
+  loopLen:         number
+}
+
+/**
+ * Ruler gestures: click/scrub to seek, drag the loop brace (body moves it,
+ * edges resize it) and the clip-end marker. Dispatches live on every move —
+ * none of this state is in the undo history (same precedent as panning).
+ */
+export function useRulerInteractions (requestRedraw: () => void) {
+  const store   = useAppStore()
+  const gesture = useRef<RulerGesture | null>(null)
+
+  const apply = useCallback(
+    (px: number) => {
+      const g = gesture.current
+      if (!g)
+        return
+
+      const state                              = store.getState()
+      const vp                                 = selectViewport(state)
+      const { loop }                           = state.transport
+      const { snapEnabled, division, triplet } = state.tool
+      const minLen                             = divisionTicks(division, triplet)
+      const tick                               = xToTick(px, vp)
+      const snap                               = (t: number): number =>
+        snapEnabled ? snapTicks(t, division, triplet) : Math.round(t)
+
+      switch (g.hit.kind) {
+        case 'seek': {
+          store.dispatch(seek(Math.max(0, snap(tick))))
+          break
+        }
+        case 'loop-body': {
+          const start = Math.max(0, snap(tick - g.grabOffsetTicks))
+          store.dispatch(setLoop({ startTicks: start, endTicks: start + g.loopLen }))
+          break
+        }
+        case 'loop-start': {
+          const start = Math.max(0, Math.min(snap(tick), loop.endTicks - minLen))
+          store.dispatch(setLoop({ startTicks: start }))
+          break
+        }
+        case 'loop-end': {
+          const end = Math.max(snap(tick), loop.startTicks + minLen)
+          store.dispatch(setLoop({ endTicks: end }))
+          break
+        }
+        case 'clip-end': {
+          store.dispatch(setClipEnd(Math.max(minLen, snap(tick))))
+          break
+        }
+      }
+      requestRedraw()
+    },
+    [ store, requestRedraw ],
+  )
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLCanvasElement>) => {
+      const state                  = store.getState()
+      const vp                     = selectViewport(state)
+      const { loop, clipEndTicks } = state.transport
+      const [ px, py ]             = localPoint(e)
+      const hit                    = rulerHitTest(px, py, vp, loop, clipEndTicks, e.pointerType)
+
+      gesture.current = {
+        hit,
+        grabOffsetTicks: xToTick(px, vp) - loop.startTicks,
+        loopLen:         loop.endTicks - loop.startTicks,
+      }
+      apply(px)
+    },
+    [ store, apply ],
+  )
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLCanvasElement>) => {
+      const [ px ] = localPoint(e)
+      apply(px)
+    },
+    [ apply ],
+  )
+
+  const onPointerUp = useCallback(
+    () => {
+      gesture.current = null
+    },
+    [],
+  )
+
+  /** Abandon the in-flight gesture (e.g. a pinch began). */
+  const cancel = useCallback(
+    () => {
+      gesture.current = null
+    },
+    [],
+  )
+
+  return useMemo(
+    () => ({ onPointerDown, onPointerMove, onPointerUp, cancel }),
+    [ onPointerDown, onPointerMove, onPointerUp, cancel ],
+  )
+}

--- a/src/components/PianoRoll/interactions/useToolInteractions.ts
+++ b/src/components/PianoRoll/interactions/useToolInteractions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import { nanoid } from '@reduxjs/toolkit'
 import { useAppStore } from '@/store/hooks'
 import { selectAllNotes } from '@/store/selectors/noteSelectors'
@@ -11,18 +11,20 @@ import {
 } from '@/store/slices/notesSlice'
 import {
   addToSelection,
-  clearSelection,
   selectOne,
   setSelection,
   toggleSelection,
 } from '@/store/slices/selectionSlice'
-import { panBy, zoomX, zoomY } from '@/store/slices/viewportSlice'
+import { panBy } from '@/store/slices/viewportSlice'
+import type { AppStore } from '@/store/store'
 import { snapTicks, floorToGrid } from '@/domain/time'
 import type { NoteId } from '@/domain/types'
 import { rectFromPoints, xToTick, yToPitch, yToPitchLane } from '@/view/coords'
+import type { Viewport } from '@/view/coords'
 import { hitTestNote, notesInRect } from '@/view/hitTest'
 import { playPreview } from '@/audio/engine'
 import type { Draft } from './types'
+import { localPoint } from './utils'
 
 
 interface Gesture {
@@ -34,17 +36,39 @@ interface Gesture {
   resizeBase:  number // start+duration of grabbed note (resize)
 }
 
+/** Draw tool on empty space: create a note and enter a resize-drag draft. */
+function beginDrawGesture (
+  store: AppStore,
+  px: number,
+  py: number,
+  vp: Viewport,
+  gesture: Gesture,
+  draftRef: React.MutableRefObject<Draft>,
+) {
+  const { division, triplet, defaultNoteDuration, playOnDraw } = store.getState().tool
+
+  const pitch = yToPitchLane(py, vp)
+  const start = floorToGrid(xToTick(px, vp), division, triplet)
+  const id    = nanoid()
+  store.dispatch(addNote({ id, pitch, start, duration: defaultNoteDuration, velocity: 100 }))
+  store.dispatch(selectOne(id))
+  if (playOnDraw)
+    playPreview(pitch, 100)
+  gesture.resizeBase = start + defaultNoteDuration
+  draftRef.current   = { kind: 'resize', noteIds: [ id ], deltaDuration: 0 }
+}
+
+/**
+ * Grid-area tool gestures (select / draw / pan). Assumes the router has
+ * already established that the pointer is over the note grid; pointer
+ * capture and region routing live in usePianoRollInteractions.
+ */
 export function useToolInteractions (
   draftRef: React.MutableRefObject<Draft>,
   requestRedraw: () => void,
 ) {
   const store   = useAppStore()
   const gesture = useRef<Gesture | null>(null)
-
-  const localPoint = (e: React.PointerEvent): [number, number] => {
-    const rect = (e.currentTarget as HTMLCanvasElement).getBoundingClientRect()
-    return [ e.clientX - rect.left, e.clientY - rect.top ]
-  }
 
   const snap = (t: number): number => {
     const { snapEnabled, division, triplet } = store.getState().tool
@@ -58,15 +82,7 @@ export function useToolInteractions (
       const vp         = selectViewport(state)
       const notes      = selectAllNotes(state)
       const [ px, py ] = localPoint(e)
-      // Clicking the left piano keyboard auditions that pitch.
-      if (px < vp.keyboardWidth && py >= vp.rulerHeight) {
-        playPreview(yToPitchLane(py, vp), 100)
-        return
-      }
-      if (px < vp.keyboardWidth || py < vp.rulerHeight)
-        return
 
-      e.currentTarget.setPointerCapture(e.pointerId)
       gesture.current = { startX: px, startY: py, lastX: px, lastY: py, anchorStart: 0, resizeBase: 0 }
 
       const hit = hitTestNote(px, py, notes, vp)
@@ -74,35 +90,23 @@ export function useToolInteractions (
       if (tool === 'pan')
         return
 
-      if (tool === 'marquee') {
-        draftRef.current = { kind: 'marquee', x1: px, y1: py, x2: px, y2: py, additive: e.shiftKey }
-        requestRedraw()
-        return
-      }
-
       if (tool === 'draw') {
         if (hit) {
           store.dispatch(removeNote(hit.id))
           return
         }
 
-        const pitch = yToPitchLane(py, vp)
-        const start = floorToGrid(xToTick(px, vp), state.tool.division, state.tool.triplet)
-        const id    = nanoid()
-        store.dispatch(addNote({ id, pitch, start, duration: state.tool.defaultNoteDuration, velocity: 100 }))
-        store.dispatch(selectOne(id))
-        if (state.tool.playOnDraw)
-          playPreview(pitch, 100)
-        gesture.current.resizeBase = start + state.tool.defaultNoteDuration
-        draftRef.current           = { kind: 'resize', noteIds: [ id ], deltaDuration: 0 }
+        beginDrawGesture(store, px, py, vp, gesture.current, draftRef)
         requestRedraw()
         return
       }
 
-      // select tool
+      // Select tool: dragging empty space rubber-band selects (Ableton-style).
+      // A zero-area marquee commits setSelection([]) on pointer-up, which is
+      // equivalent to clearing the selection, so a plain click still deselects.
       if (!hit) {
-        if (!e.shiftKey)
-          store.dispatch(clearSelection())
+        draftRef.current = { kind: 'marquee', x1: px, y1: py, x2: px, y2: py, additive: e.shiftKey }
+        requestRedraw()
         return
       }
 
@@ -182,16 +186,10 @@ export function useToolInteractions (
   )
 
   const onPointerUp = useCallback(
-    (e: React.PointerEvent<HTMLCanvasElement>) => {
+    () => {
       const draft     = draftRef.current
       const g         = gesture.current
       gesture.current = null
-      try {
-        e.currentTarget.releasePointerCapture(e.pointerId)
-      }
-      catch {
-        // ignore
-      }
       if (!draft)
         return
 
@@ -225,27 +223,18 @@ export function useToolInteractions (
     [ store, draftRef, requestRedraw ],
   )
 
-  const onWheel = useCallback(
-    (e: React.WheelEvent<HTMLCanvasElement>) => {
-      const state = store.getState()
-      const vp    = selectViewport(state)
-      const rect  = (e.currentTarget as HTMLCanvasElement).getBoundingClientRect()
-      const px    = e.clientX - rect.left
-      const py    = e.clientY - rect.top
-
-      if (e.ctrlKey || e.metaKey) {
-        const factor = e.deltaY < 0 ? 1.1 : 1 / 1.1
-        store.dispatch(zoomX({ factor, anchorTicks: xToTick(px, vp) }))
-      }
-      else if (e.altKey) {
-        const factor = e.deltaY < 0 ? 1.1 : 1 / 1.1
-        store.dispatch(zoomY({ factor, anchorPitch: yToPitch(py, vp) }))
-      }
-      else
-        store.dispatch(panBy({ dxPx: -e.deltaX, dyPx: -e.deltaY }))
+  /** Abandon the in-flight gesture without committing (e.g. a pinch began). */
+  const cancel = useCallback(
+    () => {
+      gesture.current  = null
+      draftRef.current = null
+      requestRedraw()
     },
-    [ store ],
+    [ draftRef, requestRedraw ],
   )
 
-  return { onPointerDown, onPointerMove, onPointerUp, onWheel }
+  return useMemo(
+    () => ({ onPointerDown, onPointerMove, onPointerUp, cancel }),
+    [ onPointerDown, onPointerMove, onPointerUp, cancel ],
+  )
 }

--- a/src/components/PianoRoll/interactions/utils.ts
+++ b/src/components/PianoRoll/interactions/utils.ts
@@ -1,0 +1,13 @@
+// Shared helpers for the interaction hooks.
+
+export interface ClientPointLike {
+  clientX:       number
+  clientY:       number
+  currentTarget: EventTarget & Element
+}
+
+/** Convert an event's client coordinates to canvas-local pixels. */
+export const localPoint = (e: ClientPointLike): [number, number] => {
+  const rect = e.currentTarget.getBoundingClientRect()
+  return [ e.clientX - rect.left, e.clientY - rect.top ]
+}

--- a/src/components/PianoRoll/interactions/wheelIntent.test.ts
+++ b/src/components/PianoRoll/interactions/wheelIntent.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWheelIntent } from './wheelIntent'
+import type { WheelInput } from './wheelIntent'
+
+
+const wheel = (overrides: Partial<WheelInput>): WheelInput => ({
+  deltaX:   0,
+  deltaY:   0,
+  ctrlKey:  false,
+  metaKey:  false,
+  altKey:   false,
+  shiftKey: false,
+  ...overrides,
+})
+
+describe('resolveWheelIntent', () => {
+  it('zooms X on plain vertical wheel', () => {
+    const intent = resolveWheelIntent(wheel({ deltaY: -100 }))
+    expect(intent.kind).toBe('zoomX')
+  })
+
+  it('zoom factor is > 1 for wheel up (negative deltaY) and < 1 for wheel down', () => {
+    const zoomIn  = resolveWheelIntent(wheel({ deltaY: -100 }))
+    const zoomOut = resolveWheelIntent(wheel({ deltaY: 100 }))
+    if (zoomIn.kind !== 'zoomX' || zoomOut.kind !== 'zoomX')
+      throw new Error('expected zoomX intents')
+    expect(zoomIn.factor).toBeGreaterThan(1)
+    expect(zoomOut.factor).toBeLessThan(1)
+    // Symmetric: zooming in then out by the same delta lands at 1.
+    expect(zoomIn.factor * zoomOut.factor).toBeCloseTo(1)
+  })
+
+  it('zooms X with ctrl (trackpad pinch) regardless of other axes', () => {
+    const intent = resolveWheelIntent(wheel({ deltaY: 50, deltaX: 80, ctrlKey: true }))
+    expect(intent.kind).toBe('zoomX')
+  })
+
+  it('zooms X with meta', () => {
+    expect(resolveWheelIntent(wheel({ deltaY: 10, metaKey: true })).kind).toBe('zoomX')
+  })
+
+  it('zooms Y with alt', () => {
+    expect(resolveWheelIntent(wheel({ deltaY: 10, altKey: true })).kind).toBe('zoomY')
+  })
+
+  it('pans with shift, passing both deltas through inverted', () => {
+    const intent = resolveWheelIntent(wheel({ deltaY: 40, deltaX: 8, shiftKey: true }))
+    expect(intent).toEqual({ kind: 'pan', dxPx: -8, dyPx: -40 })
+  })
+
+  it('pans horizontally when the horizontal delta dominates (trackpad swipe)', () => {
+    const intent = resolveWheelIntent(wheel({ deltaX: 90, deltaY: 12 }))
+    expect(intent).toEqual({ kind: 'pan', dxPx: -90, dyPx: 0 })
+  })
+
+  it('prefers zoom when the vertical delta dominates', () => {
+    expect(resolveWheelIntent(wheel({ deltaX: 12, deltaY: 90 })).kind).toBe('zoomX')
+  })
+
+  it('ctrl wins over alt and shift', () => {
+    const intent = resolveWheelIntent(wheel({ deltaY: 10, ctrlKey: true, altKey: true, shiftKey: true }))
+    expect(intent.kind).toBe('zoomX')
+  })
+})

--- a/src/components/PianoRoll/interactions/wheelIntent.ts
+++ b/src/components/PianoRoll/interactions/wheelIntent.ts
@@ -1,0 +1,35 @@
+// Pure mapping from a wheel event's deltas + modifiers to an editor intent.
+// Kept free of React/DOM so the priority rules are unit-testable.
+
+export type WheelIntent =
+  | { kind: 'zoomX'; factor: number } |
+  { kind: 'zoomY'; factor: number } |
+  { kind: 'pan'; dxPx: number; dyPx: number }
+
+export interface WheelInput {
+  deltaX:   number
+  deltaY:   number
+  ctrlKey:  boolean
+  metaKey:  boolean
+  altKey:   boolean
+  shiftKey: boolean
+}
+
+// Exponential factor keeps pinch-quality trackpad deltas smooth while a
+// notched mouse wheel click (deltaY ~100) lands near the familiar 1.25x step.
+const wheelZoomFactor = (deltaY: number): number => Math.exp(-deltaY * 0.0022)
+
+export function resolveWheelIntent (e: WheelInput): WheelIntent {
+  if (e.ctrlKey || e.metaKey)
+    return { kind: 'zoomX', factor: wheelZoomFactor(e.deltaY) }
+  if (e.altKey)
+    return { kind: 'zoomY', factor: wheelZoomFactor(e.deltaY) }
+  if (e.shiftKey)
+    // Vertical-scroll fallback. Browsers disagree on whether shift moves the
+    // delta into deltaX; passing both through handles either convention.
+    return { kind: 'pan', dxPx: -e.deltaX, dyPx: -e.deltaY }
+  if (Math.abs(e.deltaX) > Math.abs(e.deltaY))
+    // Dominant horizontal axis: trackpad sideways swipe pans the timeline.
+    return { kind: 'pan', dxPx: -e.deltaX, dyPx: 0 }
+  return { kind: 'zoomX', factor: wheelZoomFactor(e.deltaY) }
+}

--- a/src/components/PianoRoll/layers/gridLayer.ts
+++ b/src/components/PianoRoll/layers/gridLayer.ts
@@ -1,5 +1,5 @@
 import { divisionTicks, isBlackKey, ticksPerBar, ticksPerBeat } from '@/domain/time'
-import type { GridDivision, TimeSignature } from '@/domain/types'
+import type { GridDivision, Ticks, TimeSignature } from '@/domain/types'
 import { pitchToY, tickToX } from '@/view/coords'
 import type { Viewport } from '@/view/coords'
 import { theme } from '@/view/theme'
@@ -11,10 +11,11 @@ export interface GridData {
   triplet:       boolean
   visibleTicks:  { start: number; end: number }
   visiblePitch:  { lo: number; hi: number }
+  clipEndTicks:  Ticks
 }
 
 export function drawGrid (ctx: CanvasRenderingContext2D, vp: Viewport, data: GridData) {
-  const { timeSignature, division, triplet, visibleTicks, visiblePitch } = data
+  const { timeSignature, division, triplet, visibleTicks, visiblePitch, clipEndTicks } = data
 
   // Background.
   ctx.fillStyle = theme.bg
@@ -46,5 +47,13 @@ export function drawGrid (ctx: CanvasRenderingContext2D, vp: Viewport, data: Gri
     ctx.moveTo(x, vp.rulerHeight)
     ctx.lineTo(x, vp.height)
     ctx.stroke()
+  }
+
+  // De-emphasize the region beyond the clip end (Ableton-style).
+  const clipEndX = tickToX(clipEndTicks, vp)
+  if (clipEndX < vp.width) {
+    const x       = Math.max(clipEndX, vp.keyboardWidth)
+    ctx.fillStyle = theme.beyondClipEnd
+    ctx.fillRect(x, vp.rulerHeight, vp.width - x, vp.height - vp.rulerHeight)
   }
 }

--- a/src/components/PianoRoll/layers/rulerLayer.ts
+++ b/src/components/PianoRoll/layers/rulerLayer.ts
@@ -1,19 +1,22 @@
 import { ticksPerBar, ticksPerBeat } from '@/domain/time'
-import type { TimeSignature } from '@/domain/types'
+import type { LoopRegion, Ticks, TimeSignature } from '@/domain/types'
 import { tickToX } from '@/view/coords'
 import type { Viewport } from '@/view/coords'
+import { BRACE_BAND_RATIO } from '@/view/rulerHitTest'
 import { theme } from '@/view/theme'
 
 
 export interface RulerData {
   timeSignature: TimeSignature
   visibleTicks:  { start: number; end: number }
+  loop:          LoopRegion
+  clipEndTicks:  Ticks
 }
 
 export function drawRuler (ctx: CanvasRenderingContext2D, vp: Viewport, data: RulerData) {
-  const { timeSignature, visibleTicks } = data
-  const barStep                         = ticksPerBar(timeSignature)
-  const beatStep                        = ticksPerBeat(timeSignature)
+  const { timeSignature, visibleTicks, loop, clipEndTicks } = data
+  const barStep                                             = ticksPerBar(timeSignature)
+  const beatStep                                            = ticksPerBeat(timeSignature)
 
   ctx.fillStyle = theme.rulerBg
   ctx.fillRect(vp.keyboardWidth, 0, vp.width - vp.keyboardWidth, vp.rulerHeight)
@@ -43,5 +46,44 @@ export function drawRuler (ctx: CanvasRenderingContext2D, vp: Viewport, data: Ru
       ctx.fillText(String(barNumber), x + 3, vp.rulerHeight / 2)
     }
   }
+
+  drawLoopBrace(ctx, vp, loop)
+  drawClipEndMarker(ctx, vp, clipEndTicks)
   ctx.restore()
+}
+
+/** Ableton-style loop brace in the upper ruler band; dimmed when disabled. */
+function drawLoopBrace (ctx: CanvasRenderingContext2D, vp: Viewport, loop: LoopRegion) {
+  const bandH  = vp.rulerHeight * BRACE_BAND_RATIO
+  const startX = tickToX(loop.startTicks, vp)
+  const endX   = tickToX(loop.endTicks, vp)
+  if (endX < vp.keyboardWidth || startX > vp.width)
+    return
+
+  const color = loop.enabled ? theme.loopBrace : theme.loopBraceDim
+
+  ctx.fillStyle = color
+  ctx.fillRect(startX, 2, Math.max(1, endX - startX), bandH - 4)
+
+  // Square edge handles signal the draggable bounds.
+  ctx.fillStyle = loop.enabled ? theme.loopHandle : theme.loopBraceDim
+  ctx.fillRect(startX - 2, 1, 4, bandH - 2)
+  ctx.fillRect(endX - 2, 1, 4, bandH - 2)
+}
+
+/** Clip end: a downward flag marking where playback stops when loop is off. */
+function drawClipEndMarker (ctx: CanvasRenderingContext2D, vp: Viewport, clipEndTicks: Ticks) {
+  const x = tickToX(clipEndTicks, vp)
+  if (x < vp.keyboardWidth || x > vp.width)
+    return
+
+  const bandH   = vp.rulerHeight * BRACE_BAND_RATIO
+  ctx.fillStyle = theme.clipEnd
+  ctx.beginPath()
+  ctx.moveTo(x, 1)
+  ctx.lineTo(x - 7, 1)
+  ctx.lineTo(x, bandH)
+  ctx.closePath()
+  ctx.fill()
+  ctx.fillRect(x - 1, 1, 2, vp.rulerHeight - 2)
 }

--- a/src/components/PianoRoll/useCanvasRenderer.ts
+++ b/src/components/PianoRoll/useCanvasRenderer.ts
@@ -6,7 +6,7 @@ import {
   selectVisiblePitchRange,
   selectVisibleTickRange,
 } from '@/store/selectors/viewportSelectors'
-import type { GridDivision, Note, TimeSignature } from '@/domain/types'
+import type { GridDivision, LoopRegion, Note, TimeSignature } from '@/domain/types'
 import { drawGrid } from './layers/gridLayer'
 import { drawNotes } from './layers/notesLayer'
 import { drawWaveform } from './layers/waveformLayer'
@@ -29,6 +29,8 @@ export function useCanvasRenderer (
   const notes         = useAppSelector(selectAllNotes)
   const selectedIds   = useAppSelector(s => s.selection.selectedIds)
   const positionTicks = useAppSelector(s => s.transport.positionTicks)
+  const loop          = useAppSelector(s => s.transport.loop)
+  const clipEndTicks  = useAppSelector(s => s.transport.clipEndTicks)
   const division      = useAppSelector(s => s.tool.division)
   const triplet       = useAppSelector(s => s.tool.triplet)
   const timeSignature = useAppSelector(s => s.transport.timeSignature)
@@ -50,6 +52,8 @@ export function useCanvasRenderer (
     notes,
     selected,
     positionTicks,
+    loop,
+    clipEndTicks,
     division,
     triplet,
     timeSignature,
@@ -63,6 +67,8 @@ export function useCanvasRenderer (
     notes,
     selected,
     positionTicks,
+    loop,
+    clipEndTicks,
     division,
     triplet,
     timeSignature,
@@ -95,6 +101,8 @@ type Inputs = {
   notes:         Note[]
   selected:      Set<string>
   positionTicks: number
+  loop:          LoopRegion
+  clipEndTicks:  number
   division:      GridDivision
   triplet:       boolean
   timeSignature: TimeSignature
@@ -151,12 +159,18 @@ function draw (
     triplet:       inp.triplet,
     visibleTicks:  inp.visibleTicks,
     visiblePitch:  inp.visiblePitch,
+    clipEndTicks:  inp.clipEndTicks,
   })
   drawNotes(ctx, vp, { notes: renderNotes, selected: inp.selected })
   if (inp.showWaveform)
     drawWaveform(ctx, vp, { notes: renderNotes, bpm: inp.bpm })
   drawOverlay(ctx, vp, draft)
-  drawRuler(ctx, vp, { timeSignature: inp.timeSignature, visibleTicks: inp.visibleTicks })
+  drawRuler(ctx, vp, {
+    timeSignature: inp.timeSignature,
+    visibleTicks:  inp.visibleTicks,
+    loop:          inp.loop,
+    clipEndTicks:  inp.clipEndTicks,
+  })
   drawKeyboard(ctx, vp, { visiblePitch: inp.visiblePitch })
   drawPlayhead(ctx, vp, { positionTicks: inp.positionTicks })
 }

--- a/src/components/PreferencesPanel.tsx
+++ b/src/components/PreferencesPanel.tsx
@@ -37,6 +37,7 @@ export const PreferencesPanel = ({ onClose }: PreferencesPanelProps) => {
         <h2 id="preferences-title">Preferences</h2>
         <p>Editor defaults are saved in this browser.</p>
       </div>
+
       <button type="button" className="tool-btn" aria-label="Close preferences" onClick={ onClose }>
         <X size={ 16 } />
       </button>
@@ -44,17 +45,19 @@ export const PreferencesPanel = ({ onClose }: PreferencesPanelProps) => {
 
     <section className="preferences__section" aria-label="Grid preferences">
       <h3>Grid</h3>
+
       <label className="preferences__row preferences__row--checkbox">
         <input
           type="checkbox"
           checked={ tool.snapEnabled }
-          onChange={ e => dispatch(setSnapEnabled(e.target.checked)) }
-        />
+          onChange={ e => dispatch(setSnapEnabled(e.target.checked)) } />
+
         <span>Snap edits to the grid</span>
       </label>
 
       <label className="preferences__row">
         <span>Grid division</span>
+
         <select
           value={ tool.division }
           onChange={ e => dispatch(setDivision(Number(e.target.value) as GridDivision)) }>
@@ -66,16 +69,18 @@ export const PreferencesPanel = ({ onClose }: PreferencesPanelProps) => {
         <input
           type="checkbox"
           checked={ tool.triplet }
-          onChange={ e => dispatch(setTriplet(e.target.checked)) }
-        />
+          onChange={ e => dispatch(setTriplet(e.target.checked)) } />
+
         <span>Use triplet grid</span>
       </label>
     </section>
 
     <section className="preferences__section" aria-label="Drawing preferences">
       <h3>Drawing</h3>
+
       <label className="preferences__row">
         <span>Default note length</span>
+
         <select
           value={ tool.defaultNoteDuration }
           onChange={ e => dispatch(setDefaultNoteDuration(Number(e.target.value))) }>
@@ -89,8 +94,8 @@ export const PreferencesPanel = ({ onClose }: PreferencesPanelProps) => {
         <input
           type="checkbox"
           checked={ tool.playOnDraw }
-          onChange={ e => dispatch(setPlayOnDraw(e.target.checked)) }
-        />
+          onChange={ e => dispatch(setPlayOnDraw(e.target.checked)) } />
+
         <span>Preview notes while drawing</span>
       </label>
 
@@ -98,8 +103,8 @@ export const PreferencesPanel = ({ onClose }: PreferencesPanelProps) => {
         <input
           type="checkbox"
           checked={ tool.showWaveform }
-          onChange={ e => dispatch(setShowWaveform(e.target.checked)) }
-        />
+          onChange={ e => dispatch(setShowWaveform(e.target.checked)) } />
+
         <span>Show waveform overlays on notes</span>
       </label>
     </section>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -2,11 +2,12 @@ import {
   MousePointer2,
   Hand,
   Pencil,
-  BoxSelect,
   Magnet,
   AudioWaveform,
   Volume2,
   Settings,
+  FolderOpen,
+  Save,
 } from 'lucide-react'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import {
@@ -17,14 +18,15 @@ import {
   toggleWaveform,
   togglePlayOnDraw,
 } from '@/store/slices/toolSlice'
+import { exportMidi, importMidiFile } from '@/thunks/projectThunks'
+import { openMidiPicker } from '@/midi/filePicker'
 import type { GridDivision, ToolKind } from '@/domain/types'
 
 
 const TOOLS: { kind: ToolKind; label: string; Icon: typeof Hand; hint: string }[] = [
-  { kind: 'select', label: 'Select', Icon: MousePointer2, hint: 'Select / move / resize' },
-  { kind: 'pan', label: 'Pan', Icon: Hand, hint: 'Pan the view' },
+  { kind: 'select', label: 'Select', Icon: MousePointer2, hint: 'Select / move / resize / rubber-band' },
   { kind: 'draw', label: 'Draw', Icon: Pencil, hint: 'Draw notes (B)' },
-  { kind: 'marquee', label: 'Marquee', Icon: BoxSelect, hint: 'Rubber-band select' },
+  { kind: 'pan', label: 'Pan', Icon: Hand, hint: 'Pan the view' },
 ]
 
 const DIVISIONS: GridDivision[] = [ 1, 2, 4, 8, 16, 32 ]
@@ -41,8 +43,41 @@ export const Toolbar = ({ onOpenPreferences }: ToolbarProps) => {
   const triplet      = useAppSelector(s => s.tool.triplet)
   const showWaveform = useAppSelector(s => s.tool.showWaveform)
   const playOnDraw   = useAppSelector(s => s.tool.playOnDraw)
+  const fileName     = useAppSelector(s => s.project.fileName)
+  const dirty        = useAppSelector(s => s.project.dirty)
+
+  const openFile = async () => {
+    const file = await openMidiPicker()
+    if (file)
+      dispatch(importMidiFile(file))
+  }
 
   return <div className="toolbar">
+    <div className="toolbar__group">
+      <button
+        className="tool-btn"
+        aria-label="Open MIDI file"
+        type="button"
+        title="Open MIDI file (Ctrl/Cmd+O)"
+        onClick={ () => void openFile() }>
+        <FolderOpen size={ 16 } />
+      </button>
+
+      <button
+        className="tool-btn"
+        aria-label="Save MIDI file"
+        type="button"
+        title="Save MIDI file (Ctrl/Cmd+S)"
+        onClick={ () => dispatch(exportMidi()) }>
+        <Save size={ 16 } />
+      </button>
+
+      <span className="toolbar__filename" title={ fileName ?? 'Unsaved project' }>
+        {fileName ?? 'untitled'}
+        {dirty ? ' •' : ''}
+      </span>
+    </div>
+
     <div className="toolbar__group">
       {TOOLS.map(({ kind, label, Icon, hint }) =>
         <button

--- a/src/components/useMidiDrop.ts
+++ b/src/components/useMidiDrop.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react'
+import { useAppDispatch } from '@/store/hooks'
+import { importMidiFile } from '@/thunks/projectThunks'
+
+
+const isMidiFile = (file: File): boolean => (/\.midi?$/i).test(file.name)
+
+/** Window-level drag-and-drop of .mid/.midi files to import them. */
+export function useMidiDrop () {
+  const dispatch = useAppDispatch()
+
+  useEffect(() => {
+    const onDragOver = (e: DragEvent) => {
+      // Required so the browser allows dropping instead of navigating away.
+      e.preventDefault()
+    }
+    const onDrop = (e: DragEvent) => {
+      e.preventDefault()
+
+      const file = [ ...e.dataTransfer?.files ?? [] ].find(isMidiFile)
+      if (file)
+        dispatch(importMidiFile(file))
+    }
+
+    window.addEventListener('dragover', onDragOver)
+    window.addEventListener('drop', onDrop)
+    return () => {
+      window.removeEventListener('dragover', onDragOver)
+      window.removeEventListener('drop', onDrop)
+    }
+  }, [ dispatch ])
+}

--- a/src/domain/constants.ts
+++ b/src/domain/constants.ts
@@ -14,6 +14,13 @@ export const RULER_HEIGHT = 28
 // Resize-edge hit threshold in pixels.
 export const RESIZE_EDGE_PX = 6
 
+// Ruler marker (loop edge / clip end) grab tolerance in pixels.
+export const RULER_EDGE_TOL_PX = 6
+export const RULER_EDGE_TOL_TOUCH_PX = 14
+
+// Minimum finger spread (px) on an axis before a pinch zooms that axis.
+export const PINCH_MIN_SPREAD_PX = 24
+
 // Default viewport zoom.
 export const DEFAULT_PX_PER_TICK = 80 / PPQ // ~80px per quarter note
 export const DEFAULT_ROW_HEIGHT = 16 // px per semitone

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -15,7 +15,7 @@ export interface Note {
   velocity: Velocity
 }
 
-export type ToolKind = 'select' | 'pan' | 'draw' | 'marquee'
+export type ToolKind = 'select' | 'pan' | 'draw'
 
 // Grid divisions expressed as 1/n notes. Triplet variants are derived separately.
 export type GridDivision = 1 | 2 | 4 | 8 | 16 | 32

--- a/src/index.css
+++ b/src/index.css
@@ -105,6 +105,16 @@ body {
   font-size: 12px;
 }
 
+.toolbar__filename {
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  color: var(--text-dim, #9aa0ad);
+  padding: 0 4px;
+}
+
 .transport__bpm {
   display: inline-flex;
   align-items: center;

--- a/src/keymap/keymap.ts
+++ b/src/keymap/keymap.ts
@@ -14,6 +14,8 @@ import {
   undo,
   redo,
 } from '@/thunks/editingThunks'
+import { exportMidi, importMidiFile } from '@/thunks/projectThunks'
+import { openMidiPicker } from '@/midi/filePicker'
 
 
 export interface ShortcutContext {
@@ -52,6 +54,18 @@ export const SHORTCUTS: Shortcut[] = [
         dispatch(togglePlay())
     } },
   { key: 'l', mod: true, description: 'Toggle Loop', run: ({ dispatch }) => dispatch(toggleLoop()) },
+
+  // File
+  { key:         'o',
+    mod:         true,
+    description: 'Open MIDI file',
+    run:         ({ dispatch }) => {
+      void openMidiPicker().then(file => {
+        if (file)
+          dispatch(importMidiFile(file))
+      })
+    } },
+  { key: 's', mod: true, description: 'Save MIDI file', run: ({ dispatch }) => dispatch(exportMidi()) },
 
   // Editing
   { key: 'delete', description: 'Delete selected', run: ({ dispatch }) => dispatch(deleteSelected()) },

--- a/src/midi/filePicker.ts
+++ b/src/midi/filePicker.ts
@@ -1,0 +1,18 @@
+// Transient <input type="file"> wrapper for opening a MIDI file. Callable from
+// both toolbar clicks and keyboard shortcuts (keydown counts as activation).
+
+export function openMidiPicker (): Promise<File | null> {
+  return new Promise(resolve => {
+    const input  = document.createElement('input')
+    input.type   = 'file'
+    input.accept = '.mid,.midi,audio/midi'
+
+    input.addEventListener('change', () => {
+      resolve(input.files?.[0] ?? null)
+    })
+    // No reliable cancel event exists across browsers; resolving on the next
+    // focus return would be brittle. Unresolved promises are garbage-collected
+    // with the input, so leaking a cancelled pick is harmless.
+    input.click()
+  })
+}

--- a/src/midi/smf.test.ts
+++ b/src/midi/smf.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest'
+import type { Note } from '@/domain/types'
+import { encodeSmf } from './smfEncode'
+import { parseSmf } from './smfParse'
+import { readVarLen, writeVarLen } from './vlq'
+
+
+describe('variable-length quantities', () => {
+  it.each([
+    [ 0, [ 0x00 ]],
+    [ 127, [ 0x7f ]],
+    [ 128, [ 0x81, 0x00 ]],
+    [ 0x3fff, [ 0xff, 0x7f ]],
+    [ 0x1fffff, [ 0xff, 0xff, 0x7f ]],
+    [ 0x0fffffff, [ 0xff, 0xff, 0xff, 0x7f ]],
+  ])('encodes %i to the canonical byte sequence', (value, bytes) => {
+    expect(writeVarLen(value)).toEqual(bytes)
+  })
+
+  it.each([ 0, 1, 127, 128, 200, 0x3fff, 0x4000, 0x1fffff, 0x0fffffff ])(
+    'roundtrips %i',
+    value => {
+      const bytes                   = new Uint8Array(writeVarLen(value))
+      const { value: parsed, next } = readVarLen(bytes, 0)
+      expect(parsed).toBe(value)
+      expect(next).toBe(bytes.length)
+    },
+  )
+
+  it('throws on truncated input', () => {
+    expect(() => readVarLen(new Uint8Array([ 0x81 ]), 0)).toThrow()
+  })
+})
+
+const notes: Note[] = [
+  { id: 'a', pitch: 60, start: 0, duration: 480, velocity: 100 },
+  { id: 'b', pitch: 64, start: 480, duration: 960, velocity: 90 },
+  { id: 'c', pitch: 67, start: 480, duration: 240, velocity: 127 },
+]
+
+describe('SMF encode/parse roundtrip', () => {
+  it('preserves notes, bpm and time signature at PPQ 960', () => {
+    const bytes  = encodeSmf({ notes, bpm: 132, timeSignature: { numerator: 3, denominator: 4 }, ppq: 960 })
+    const parsed = parseSmf(bytes, 960)
+
+    expect(parsed.bpm).toBeCloseTo(132, 1)
+    expect(parsed.timeSignature).toEqual({ numerator: 3, denominator: 4 })
+    expect(parsed.notes).toHaveLength(3)
+
+    const sorted = [ ...notes ].sort((a, b) => a.start - b.start || a.pitch - b.pitch)
+    parsed.notes.forEach((n, i) => {
+      expect(n.pitch).toBe(sorted[i].pitch)
+      expect(n.start).toBe(sorted[i].start)
+      expect(n.duration).toBe(sorted[i].duration)
+      expect(n.velocity).toBe(sorted[i].velocity)
+    })
+  })
+
+  it('rescales ticks when the file PPQ differs from the target', () => {
+    const bytes  = encodeSmf({ notes, bpm: 120, timeSignature: { numerator: 4, denominator: 4 }, ppq: 480 })
+    const parsed = parseSmf(bytes, 960)
+    const first  = parsed.notes[0]
+    expect(first.start).toBe(0)
+    expect(first.duration).toBe(960) // 480 ticks at PPQ 480 = one quarter = 960 at PPQ 960
+  })
+})
+
+/** Hand-build a track chunk from event byte arrays. */
+function track (...events: number[][]): number[] {
+  const body = events.flat()
+  return [
+    0x4d, 0x54, 0x72, 0x6b, // MTrk
+    body.length >>> 24 & 0xff, body.length >>> 16 & 0xff, body.length >>> 8 & 0xff, body.length & 0xff,
+    ...body,
+  ]
+}
+
+function smf (format: number, division: number, ...tracks: number[][]): Uint8Array {
+  return new Uint8Array([
+    0x4d, 0x54, 0x68, 0x64, // MThd
+    0, 0, 0, 6,
+    0, format,
+    tracks.length >>> 8 & 0xff, tracks.length & 0xff,
+    division >>> 8 & 0xff, division & 0xff,
+    ...tracks.flat(),
+  ])
+}
+
+const END_OF_TRACK = [ 0x00, 0xff, 0x2f, 0x00 ]
+
+describe('SMF parsing details', () => {
+  it('merges notes across the tracks of a format 1 file', () => {
+    const tempoTrack = track(
+      [ 0x00, 0xff, 0x51, 0x03, 0x07, 0xa1, 0x20 ], // 500000 us/quarter = 120 bpm
+      END_OF_TRACK,
+    )
+    const noteTrack1 = track(
+      [ 0x00, 0x90, 60, 100 ],
+      [ 96, 0x80, 60, 0 ],
+      END_OF_TRACK,
+    )
+    const noteTrack2 = track(
+      [ 48, 0x91, 64, 80 ], // channel 1
+      [ 48, 0x81, 64, 0 ],
+      END_OF_TRACK,
+    )
+
+    const parsed = parseSmf(smf(1, 96, tempoTrack, noteTrack1, noteTrack2), 96)
+    expect(parsed.bpm).toBe(120)
+    expect(parsed.notes).toEqual([
+      { pitch: 60, start: 0, duration: 96, velocity: 100 },
+      { pitch: 64, start: 48, duration: 48, velocity: 80 },
+    ])
+  })
+
+  it('handles running status', () => {
+    const t = track(
+      [ 0x00, 0x90, 60, 100 ],
+      [ 0x00, 64, 100 ], // running status: another note-on
+      [ 96, 60, 0 ], // running status note-on with velocity 0 = note-off
+      [ 0x00, 64, 0 ],
+      END_OF_TRACK,
+    )
+    const parsed = parseSmf(smf(0, 96, t), 96)
+    expect(parsed.notes).toEqual([
+      { pitch: 60, start: 0, duration: 96, velocity: 100 },
+      { pitch: 64, start: 0, duration: 96, velocity: 100 },
+    ])
+  })
+
+  it('closes unterminated note-ons at end of track', () => {
+    const t = track(
+      [ 0x00, 0x90, 60, 100 ],
+      [ 96, 0xff, 0x2f, 0x00 ], // end of track 96 ticks later, no note-off
+    )
+    const parsed = parseSmf(smf(0, 96, t), 96)
+    expect(parsed.notes).toEqual([
+      { pitch: 60, start: 0, duration: 96, velocity: 100 },
+    ])
+  })
+
+  it('skips unknown meta and sysex events', () => {
+    const t = track(
+      [ 0x00, 0xff, 0x03, 0x04, 0x54, 0x65, 0x73, 0x74 ], // track name "Test"
+      [ 0x00, 0xf0, 0x03, 0x01, 0x02, 0xf7 ], // sysex
+      [ 0x00, 0x90, 60, 100 ],
+      [ 96, 0x80, 60, 0 ],
+      END_OF_TRACK,
+    )
+    const parsed = parseSmf(smf(0, 96, t), 96)
+    expect(parsed.notes).toHaveLength(1)
+  })
+
+  it('rejects format 2 files', () => {
+    expect(() => parseSmf(smf(2, 96, track(END_OF_TRACK)), 960)).toThrow(/format 2/)
+  })
+
+  it('rejects SMPTE time division', () => {
+    expect(() => parseSmf(smf(0, 0xe250, track(END_OF_TRACK)), 960)).toThrow(/SMPTE/)
+  })
+
+  it('rejects non-MIDI data', () => {
+    expect(() => parseSmf(new Uint8Array([ 1, 2, 3 ]), 960)).toThrow(/MThd/)
+  })
+})

--- a/src/midi/smfEncode.ts
+++ b/src/midi/smfEncode.ts
@@ -1,0 +1,74 @@
+// Standard MIDI File (SMF) type 0 encoder. Pure: domain objects in, bytes out.
+// Written with explicit status bytes (no running status) for maximal
+// compatibility with simple readers.
+
+import type { Note, TimeSignature } from '@/domain/types'
+import { writeVarLen } from './vlq'
+
+
+export interface SmfExportData {
+  notes:         Note[]
+  bpm:           number
+  timeSignature: TimeSignature
+  ppq:           number
+}
+
+interface TrackEvent {
+  tick:  number
+  order: number // sort key at equal tick: offs (0) before meta (1) before ons (2)
+  bytes: number[]
+}
+
+const ascii = (s: string): number[] => [ ...s ].map(c => c.charCodeAt(0))
+
+const u16 = (n: number): number[] => [ n >>> 8 & 0xff, n & 0xff ]
+const u32 = (n: number): number[] => [ n >>> 24 & 0xff, n >>> 16 & 0xff, n >>> 8 & 0xff, n & 0xff ]
+
+const clamp7 = (n: number): number => Math.max(0, Math.min(127, Math.round(n)))
+
+export function encodeSmf (data: SmfExportData): Uint8Array {
+  const { notes, bpm, timeSignature, ppq } = data
+
+  const events: TrackEvent[] = []
+
+  // Tempo meta: microseconds per quarter note.
+  const usPerQuarter = Math.round(60_000_000 / bpm)
+  events.push({
+    tick:  0,
+    order: 1,
+    bytes: [ 0xff, 0x51, 0x03, usPerQuarter >>> 16 & 0xff, usPerQuarter >>> 8 & 0xff, usPerQuarter & 0xff ],
+  })
+
+  // Time signature meta: denominator stored as a power of two.
+  const denomPow = Math.max(0, Math.round(Math.log2(timeSignature.denominator)))
+  events.push({
+    tick:  0,
+    order: 1,
+    bytes: [ 0xff, 0x58, 0x04, timeSignature.numerator & 0xff, denomPow, 24, 8 ],
+  })
+
+  for (const note of notes) {
+    const pitch    = clamp7(note.pitch)
+    const velocity = Math.max(1, clamp7(note.velocity))
+    const start    = Math.max(0, Math.round(note.start))
+    const end      = start + Math.max(1, Math.round(note.duration))
+    events.push({ tick: start, order: 2, bytes: [ 0x90, pitch, velocity ]})
+    events.push({ tick: end, order: 0, bytes: [ 0x80, pitch, 0 ]})
+  }
+
+  events.sort((a, b) => a.tick - b.tick || a.order - b.order)
+
+  const track: number[] = []
+  let lastTick          = 0
+  for (const ev of events) {
+    track.push(...writeVarLen(ev.tick - lastTick), ...ev.bytes)
+    lastTick = ev.tick
+  }
+  track.push(...writeVarLen(0), 0xff, 0x2f, 0x00) // end of track
+
+  const bytes = [
+    ...ascii('MThd'), ...u32(6), ...u16(0), ...u16(1), ...u16(ppq),
+    ...ascii('MTrk'), ...u32(track.length), ...track,
+  ]
+  return new Uint8Array(bytes)
+}

--- a/src/midi/smfParse.ts
+++ b/src/midi/smfParse.ts
@@ -1,0 +1,217 @@
+// Standard MIDI File (SMF) parser for format 0 and 1. Pure: bytes in, plain
+// domain objects out (ticks already rescaled to the project PPQ). Handles
+// running status, note-on velocity 0 as note-off, and skips unrecognized
+// meta/sysex events by their declared lengths.
+
+import type { Note, TimeSignature } from '@/domain/types'
+import { readVarLen } from './vlq'
+
+
+export interface SmfImportResult {
+  notes:          Omit<Note, 'id'>[]
+  bpm?:           number
+  timeSignature?: TimeSignature
+}
+
+interface PendingNote {
+  startTick: number
+  velocity:  number
+}
+
+const readU16 = (b: Uint8Array, o: number): number => (b[o] << 8) + b[o + 1]
+const readU32 = (b: Uint8Array, o: number): number =>
+  b[o] * 0x1000000 + (b[o + 1] << 16) + (b[o + 2] << 8) + b[o + 3]
+
+const asciiAt = (b: Uint8Array, o: number, len: number): string =>
+  String.fromCharCode(...b.subarray(o, o + len))
+
+export function parseSmf (bytes: Uint8Array, targetPpq: number): SmfImportResult {
+  if (bytes.length < 14 || asciiAt(bytes, 0, 4) !== 'MThd')
+    throw new Error('Not a Standard MIDI File (missing MThd header)')
+
+  const headerLen = readU32(bytes, 4)
+  const format    = readU16(bytes, 8)
+  const ntrks     = readU16(bytes, 10)
+  const division  = readU16(bytes, 12)
+
+  if (format !== 0 && format !== 1)
+    throw new Error(`Unsupported MIDI file format ${format}; only formats 0 and 1 are supported`)
+  if ((division & 0x8000) !== 0)
+    throw new Error('SMPTE time division is not supported; only PPQ-based files can be imported')
+  if (division === 0)
+    throw new Error('Invalid MIDI file: time division is zero')
+
+  const scale = (t: number): number => Math.round(t * targetPpq / division)
+
+  const result: SmfImportResult = { notes: []}
+  let offset                    = 8 + headerLen
+
+  for (let trackIndex = 0; trackIndex < ntrks && offset + 8 <= bytes.length; trackIndex++) {
+    if (asciiAt(bytes, offset, 4) !== 'MTrk')
+      throw new Error('Invalid MIDI file: expected MTrk chunk')
+
+    const trackLen = readU32(bytes, offset + 4)
+    const start    = offset + 8
+    const end      = Math.min(start + trackLen, bytes.length)
+    new TrackParser(bytes, start, end, scale, result).run()
+    offset = start + trackLen
+  }
+
+  result.notes.sort((a, b) => a.start - b.start || a.pitch - b.pitch)
+  return result
+}
+
+/** Streams one MTrk chunk, accumulating notes and meta into the result. */
+class TrackParser {
+  // Note-ons awaiting their note-off, keyed by channel and pitch. A stack per
+  // key tolerates overlapping identical notes (last-on, first-off pairing).
+  private pending = new Map<number, PendingNote[]>()
+
+  private offset: number
+  private tick = 0
+  private runningStatus = 0
+
+  constructor (
+    private bytes: Uint8Array,
+    start: number,
+    private end: number,
+    private scale: (t: number) => number,
+    private result: SmfImportResult,
+  ) {
+    this.offset = start
+  }
+
+  run () {
+    while (this.offset < this.end) {
+      const delta = readVarLen(this.bytes, this.offset)
+      this.tick  += delta.value
+      this.offset = delta.next
+
+      const status = this.readStatus()
+      if (status === 0xff) {
+        if (this.handleMeta())
+          break
+      }
+      else if (status === 0xf0 || status === 0xf7)
+        this.skipSysex()
+      else
+        this.handleChannelEvent(status)
+    }
+    this.closeUnterminated()
+  }
+
+  private readStatus (): number {
+    const byte = this.bytes[this.offset]
+    if (byte >= 0x80) {
+      this.offset += 1
+      if (byte < 0xf0)
+        this.runningStatus = byte
+      return byte
+    }
+    // Running status: reuse the previous channel-voice status byte.
+    if (this.runningStatus === 0)
+      throw new Error('Invalid MIDI file: data byte without a preceding status byte')
+    return this.runningStatus
+  }
+
+  /** Returns true on the end-of-track meta event. */
+  private handleMeta (): boolean {
+    const type = this.bytes[this.offset]
+    const len  = readVarLen(this.bytes, this.offset + 1)
+
+    if (type === 0x51 && len.value === 3)
+      this.readTempo(len.next)
+    if (type === 0x58 && len.value >= 2)
+      this.readTimeSignature(len.next)
+
+    this.offset = len.next + len.value
+    return type === 0x2f
+  }
+
+  private readTempo (at: number) {
+    if (this.result.bpm !== undefined)
+      return
+
+    const usPerQuarter = (this.bytes[at] << 16) + (this.bytes[at + 1] << 8) + this.bytes[at + 2]
+    if (usPerQuarter > 0)
+      this.result.bpm = Math.round(60_000_000 / usPerQuarter * 100) / 100
+  }
+
+  private readTimeSignature (at: number) {
+    if (this.result.timeSignature !== undefined)
+      return
+    this.result.timeSignature = {
+      numerator:   this.bytes[at],
+      denominator: 2 ** this.bytes[at + 1],
+    }
+  }
+
+  private skipSysex () {
+    const len   = readVarLen(this.bytes, this.offset)
+    this.offset = len.next + len.value
+  }
+
+  private handleChannelEvent (status: number) {
+    const kind    = status & 0xf0
+    const channel = status & 0x0f
+
+    switch (kind) {
+      case 0x90: {
+        const pitch    = this.bytes[this.offset]
+        const velocity = this.bytes[this.offset + 1]
+        this.offset   += 2
+        // Note-on with velocity 0 is a note-off by convention.
+        if (velocity === 0)
+          this.closeNote(channel << 8 | pitch, pitch, this.tick)
+        else
+          this.openNote(channel << 8 | pitch, velocity)
+        break
+      }
+      case 0x80: {
+        const pitch  = this.bytes[this.offset]
+        this.offset += 2
+        this.closeNote(channel << 8 | pitch, pitch, this.tick)
+        break
+      }
+      case 0xa0: // polyphonic aftertouch
+      case 0xb0: // control change
+      case 0xe0: { // pitch bend
+        this.offset += 2
+        break
+      }
+      case 0xc0: // program change
+      case 0xd0: { // channel aftertouch
+        this.offset += 1
+        break
+      }
+      default:
+        throw new Error(`Invalid MIDI file: unexpected status byte 0x${status.toString(16)}`)
+    }
+  }
+
+  private openNote (key: number, velocity: number) {
+    const stack = this.pending.get(key) ?? []
+    stack.push({ startTick: this.tick, velocity })
+    this.pending.set(key, stack)
+  }
+
+  private closeNote (key: number, pitch: number, endTick: number) {
+    const stack = this.pending.get(key)
+    const open  = stack?.pop()
+    if (!open)
+      return
+    this.result.notes.push({
+      pitch,
+      start:    this.scale(open.startTick),
+      duration: Math.max(1, this.scale(endTick) - this.scale(open.startTick)),
+      velocity: open.velocity,
+    })
+  }
+
+  /** Close any unterminated note-ons at end of track. */
+  private closeUnterminated () {
+    for (const [ key, stack ] of this.pending)
+      while (stack.length > 0)
+        this.closeNote(key, key & 0xff, this.tick)
+  }
+}

--- a/src/midi/vlq.ts
+++ b/src/midi/vlq.ts
@@ -1,0 +1,32 @@
+// Variable-length quantity encoding used by Standard MIDI Files.
+
+/** Encode a non-negative integer as a MIDI variable-length quantity. */
+export function writeVarLen (n: number): number[] {
+  let value = Math.max(0, Math.floor(n))
+  const out = [ value & 0x7f ]
+  value >>>= 7
+  while (value > 0) {
+    out.unshift(value & 0x7f | 0x80)
+    value >>>= 7
+  }
+  return out
+}
+
+/** Decode a variable-length quantity; returns the value and the next offset. */
+type ReadVarLenReturnType = { value: number; next: number }
+
+export function readVarLen (bytes: Uint8Array, offset: number): ReadVarLenReturnType {
+  let value = 0
+  let i     = offset
+  for (;;) {
+    if (i >= bytes.length)
+      throw new Error('Unexpected end of data while reading variable-length quantity')
+
+    const byte = bytes[i]
+    value      = value * 128 + (byte & 0x7f)
+    i         += 1
+    if ((byte & 0x80) === 0)
+      break
+  }
+  return { value, next: i }
+}

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -1,8 +1,10 @@
 import type { Middleware } from '@reduxjs/toolkit'
-import { initialToolState, type ToolState } from './slices/toolSlice'
+import { initialToolState } from './slices/toolSlice'
+import type { ToolState } from './slices/toolSlice'
 import type { GridDivision } from '@/domain/types'
 
-const STORAGE_KEY = 'tween-midi-editor.preferences'
+
+const STORAGE_KEY               = 'tween-midi-editor.preferences'
 const DIVISIONS: GridDivision[] = [ 1, 2, 4, 8, 16, 32 ]
 
 type PersistedPreferences = Pick<
@@ -45,7 +47,8 @@ export const loadToolPreferences = (): Partial<ToolState> => {
       preferences.playOnDraw = parsed.playOnDraw
 
     return preferences
-  } catch {
+  }
+  catch {
     return {}
   }
 }
@@ -73,7 +76,8 @@ export const preferencesMiddleware: Middleware = storeApi => next => action => {
   try {
     const state = storeApi.getState() as { tool: ToolState }
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(selectPersistedPreferences(state.tool)))
-  } catch {
+  }
+  catch {
     // Persistence is best-effort: private browsing and storage quotas should not break editing.
   }
 

--- a/src/store/projectMiddleware.ts
+++ b/src/store/projectMiddleware.ts
@@ -1,0 +1,30 @@
+import type { Middleware } from '@reduxjs/toolkit'
+import { markDirty } from './slices/projectSlice'
+import type { ProjectState } from './slices/projectSlice'
+
+// Actions that change document content (as opposed to view/selection/transport
+// position) flip the project's dirty flag until the next save/load.
+const CONTENT_ACTION_PREFIXES = [ 'notes/' ]
+const CONTENT_ACTION_TYPES    = new Set([
+  'transport/setBpm',
+  'transport/setTimeSignature',
+  'transport/setLoop',
+  'transport/setClipEnd',
+  '@@redux-undo/UNDO',
+  '@@redux-undo/REDO',
+])
+
+const isContentAction = (type: string): boolean =>
+  CONTENT_ACTION_TYPES.has(type) ||
+  CONTENT_ACTION_PREFIXES.some(prefix => type.startsWith(prefix))
+
+export const projectMiddleware: Middleware = storeApi => next => action => {
+  const result = next(action)
+
+  const { type }  = action as { type: string }
+  const { dirty } = (storeApi.getState() as { project: ProjectState }).project
+  if (!dirty && isContentAction(type))
+    storeApi.dispatch(markDirty())
+
+  return result
+}

--- a/src/store/slices/notesSlice.test.ts
+++ b/src/store/slices/notesSlice.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import reducer, {
   addNote,
   moveNotesBy,
+  setAllNotes,
   setNoteVelocity,
   updateNote,
   notesAdapter,
@@ -47,5 +48,14 @@ describe('notesSlice', () => {
     let state = reducer(empty, addNote({ id: 'd', pitch: 60, start: 0, duration: 100, velocity: 50 }))
     state = reducer(state, updateNote({ id: 'd', changes: { duration: -50 }}))
     expect(selectors.selectById(state, 'd')!.duration).toBe(1)
+  })
+
+  it('setAllNotes replaces the whole collection', () => {
+    let state = reducer(empty, addNote({ id: 'gone', pitch: 60, start: 0, duration: 100, velocity: 50 }))
+    state = reducer(state, setAllNotes([
+      { id: 'n1', pitch: 61, start: 0, duration: 10, velocity: 100 },
+      { id: 'n2', pitch: 62, start: 10, duration: 10, velocity: 100 },
+    ]))
+    expect(selectors.selectAll(state).map(n => n.id)).toEqual([ 'n1', 'n2' ])
   })
 })

--- a/src/store/slices/notesSlice.ts
+++ b/src/store/slices/notesSlice.ts
@@ -32,6 +32,9 @@ const notesSlice = createSlice({
     removeNote:  notesAdapter.removeOne,
     removeNotes: notesAdapter.removeMany,
 
+    /** Replace the whole document's notes (file import). */
+    setAllNotes: notesAdapter.setAll,
+
     updateNote: (
       state,
       action: PayloadAction<{ id: NoteId; changes: Partial<Omit<Note, 'id'>> }>,
@@ -98,6 +101,7 @@ export const {
   addNotes,
   removeNote,
   removeNotes,
+  setAllNotes,
   updateNote,
   updateNotes,
   moveNotesBy,

--- a/src/store/slices/projectSlice.test.ts
+++ b/src/store/slices/projectSlice.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import reducer, { markClean, markDirty, setFileName } from './projectSlice'
+
+
+const initial = reducer(undefined, { type: '@@INIT' })
+
+describe('projectSlice', () => {
+  it('starts clean and unnamed', () => {
+    expect(initial).toEqual({ fileName: null, dirty: false })
+  })
+
+  it('sets and clears the file name', () => {
+    const named = reducer(initial, setFileName('song.mid'))
+    expect(named.fileName).toBe('song.mid')
+    expect(reducer(named, setFileName(null)).fileName).toBeNull()
+  })
+
+  it('marks dirty and clean', () => {
+    const dirty = reducer(initial, markDirty())
+    expect(dirty.dirty).toBe(true)
+    expect(reducer(dirty, markClean()).dirty).toBe(false)
+  })
+})

--- a/src/store/slices/projectSlice.ts
+++ b/src/store/slices/projectSlice.ts
@@ -1,0 +1,33 @@
+import { createSlice } from '@reduxjs/toolkit'
+import type { PayloadAction } from '@reduxjs/toolkit'
+
+
+export interface ProjectState {
+  fileName: string | null
+  dirty:    boolean
+}
+
+const initialState: ProjectState = {
+  fileName: null,
+  dirty:    false,
+}
+
+const projectSlice = createSlice({
+  name:     'project',
+  initialState,
+  reducers: {
+    setFileName: (state, action: PayloadAction<string | null>) => {
+      state.fileName = action.payload
+    },
+    markDirty: state => {
+      state.dirty = true
+    },
+    markClean: state => {
+      state.dirty = false
+    },
+  },
+})
+
+export const { setFileName, markDirty, markClean } = projectSlice.actions
+
+export default projectSlice.reducer

--- a/src/store/slices/transportSlice.test.ts
+++ b/src/store/slices/transportSlice.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { ticksPerBar, ticksPerBeat } from '@/domain/time'
+import { DEFAULT_TIME_SIGNATURE } from '@/domain/constants'
+import reducer, { setClipEnd, setLoop, toggleLoop } from './transportSlice'
+
+
+const initial = reducer(undefined, { type: '@@INIT' })
+
+describe('transportSlice', () => {
+  it('defaults the clip end and loop end to four bars', () => {
+    const fourBars = ticksPerBar(DEFAULT_TIME_SIGNATURE) * 4
+    expect(initial.clipEndTicks).toBe(fourBars)
+    expect(initial.loop.endTicks).toBe(fourBars)
+  })
+
+  describe('setLoop', () => {
+    it('applies partial payloads', () => {
+      const next = reducer(initial, setLoop({ startTicks: 960 }))
+      expect(next.loop.startTicks).toBe(960)
+      expect(next.loop.endTicks).toBe(initial.loop.endTicks)
+      expect(next.loop.enabled).toBe(initial.loop.enabled)
+    })
+
+    it('clamps a negative start to zero', () => {
+      const next = reducer(initial, setLoop({ startTicks: -50 }))
+      expect(next.loop.startTicks).toBe(0)
+    })
+
+    it('keeps the end strictly after the start', () => {
+      const next = reducer(initial, setLoop({ startTicks: 1000, endTicks: 900 }))
+      expect(next.loop.startTicks).toBe(1000)
+      expect(next.loop.endTicks).toBe(1001)
+    })
+
+    it('rounds fractional ticks', () => {
+      const next = reducer(initial, setLoop({ startTicks: 10.4, endTicks: 20.6 }))
+      expect(next.loop.startTicks).toBe(10)
+      expect(next.loop.endTicks).toBe(21)
+    })
+  })
+
+  describe('toggleLoop', () => {
+    it('flips the enabled flag', () => {
+      const on = reducer(initial, toggleLoop())
+      expect(on.loop.enabled).toBe(!initial.loop.enabled)
+      expect(reducer(on, toggleLoop()).loop.enabled).toBe(initial.loop.enabled)
+    })
+  })
+
+  describe('setClipEnd', () => {
+    it('sets and rounds the clip end', () => {
+      const next = reducer(initial, setClipEnd(1234.6))
+      expect(next.clipEndTicks).toBe(1235)
+    })
+
+    it('enforces a minimum of one beat', () => {
+      const beat = ticksPerBeat(initial.timeSignature)
+      const next = reducer(initial, setClipEnd(1))
+      expect(next.clipEndTicks).toBe(beat)
+    })
+  })
+})

--- a/src/store/slices/transportSlice.ts
+++ b/src/store/slices/transportSlice.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_BPM,
   DEFAULT_TIME_SIGNATURE,
 } from '@/domain/constants'
-import { ticksPerBar } from '@/domain/time'
+import { ticksPerBar, ticksPerBeat } from '@/domain/time'
 import type { LoopRegion, Ticks, TimeSignature } from '@/domain/types'
 
 
@@ -13,6 +13,7 @@ interface TransportState {
   bpm:           number
   positionTicks: Ticks
   loop:          LoopRegion
+  clipEndTicks:  Ticks
   timeSignature: TimeSignature
   metronome:     boolean
 }
@@ -26,6 +27,7 @@ const initialState: TransportState = {
     startTicks: 0,
     endTicks:   ticksPerBar(DEFAULT_TIME_SIGNATURE) * 4,
   },
+  clipEndTicks:  ticksPerBar(DEFAULT_TIME_SIGNATURE) * 4,
   timeSignature: DEFAULT_TIME_SIGNATURE,
   metronome:     false,
 }
@@ -57,10 +59,18 @@ const transportSlice = createSlice({
       state.positionTicks = Math.max(0, action.payload)
     },
     setLoop: (state, action: PayloadAction<Partial<LoopRegion>>) => {
-      state.loop = { ...state.loop, ...action.payload }
+      const next      = { ...state.loop, ...action.payload }
+      next.startTicks = Math.max(0, Math.round(next.startTicks))
+      next.endTicks   = Math.max(next.startTicks + 1, Math.round(next.endTicks))
+      state.loop      = next
     },
     toggleLoop: state => {
       state.loop.enabled = !state.loop.enabled
+    },
+
+    /** Clip end marker; playback stops here when looping is disabled. */
+    setClipEnd: (state, action: PayloadAction<Ticks>) => {
+      state.clipEndTicks = Math.max(ticksPerBeat(state.timeSignature), Math.round(action.payload))
     },
     setTimeSignature: (state, action: PayloadAction<TimeSignature>) => {
       state.timeSignature = action.payload
@@ -80,6 +90,7 @@ export const {
   seek,
   setLoop,
   toggleLoop,
+  setClipEnd,
   setTimeSignature,
   toggleMetronome,
 } = transportSlice.actions

--- a/src/store/slices/viewportSlice.test.ts
+++ b/src/store/slices/viewportSlice.test.ts
@@ -36,4 +36,12 @@ describe('viewportSlice', () => {
     const after  = reducer(before, panBy({ dxPx: 100000, dyPx: 0 }))
     expect(after.scrollTicks).toBe(0)
   })
+
+  it('zoomX never scrolls past tick 0 when zooming out near the origin', () => {
+    const before = reducer(undefined, { type: '@@INIT' })
+    // Zooming out anchored right of the origin would otherwise solve for a
+    // negative scrollTicks and expose bars before 1.
+    const after = reducer(before, zoomX({ factor: 0.25, anchorTicks: before.scrollTicks + 500 }))
+    expect(after.scrollTicks).toBe(0)
+  })
 })

--- a/src/store/slices/viewportSlice.ts
+++ b/src/store/slices/viewportSlice.ts
@@ -45,8 +45,10 @@ const viewportSlice = createSlice({
       const { factor, anchorTicks } = action.payload
       const next                    = clamp(state.pxPerTick * factor, MIN_PX_PER_TICK, MAX_PX_PER_TICK)
       // Keep the anchor pixel fixed: solve for new scrollTicks.
-      state.scrollTicks =
-        anchorTicks - (anchorTicks - state.scrollTicks) * state.pxPerTick / next
+      state.scrollTicks = Math.max(
+        0,
+        anchorTicks - (anchorTicks - state.scrollTicks) * state.pxPerTick / next,
+      )
       state.pxPerTick = next
     },
 
@@ -57,8 +59,11 @@ const viewportSlice = createSlice({
     ) => {
       const { factor, anchorPitch } = action.payload
       const next                    = clamp(state.rowHeight * factor, MIN_ROW_HEIGHT, MAX_ROW_HEIGHT)
-      state.scrollPitch             =
-        anchorPitch + (state.scrollPitch - anchorPitch) * state.rowHeight / next
+      state.scrollPitch             = clamp(
+        anchorPitch + (state.scrollPitch - anchorPitch) * state.rowHeight / next,
+        0,
+        MAX_NOTE,
+      )
       state.rowHeight = next
     },
     setScroll: (

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,11 +1,13 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit'
 import undoable, { excludeAction } from 'redux-undo'
 import notesReducer from './slices/notesSlice'
+import projectReducer from './slices/projectSlice'
 import selectionReducer from './slices/selectionSlice'
 import toolReducer from './slices/toolSlice'
 import transportReducer from './slices/transportSlice'
 import viewportReducer from './slices/viewportSlice'
 import { persistedToolState, preferencesMiddleware } from './persistence'
+import { projectMiddleware } from './projectMiddleware'
 
 // Only the note data is historized for undo/redo. Transport position updates are
 // dispatched continuously by the audio engine, so they must never create history.
@@ -16,6 +18,7 @@ const notesUndoable = undoable(notesReducer, {
 
 const rootReducer = combineReducers({
   notes:     notesUndoable,
+  project:   projectReducer,
   selection: selectionReducer,
   tool:      toolReducer,
   transport: transportReducer,
@@ -23,11 +26,12 @@ const rootReducer = combineReducers({
 })
 
 export const store = configureStore({
-  reducer: rootReducer,
+  reducer:        rootReducer,
   preloadedState: {
     tool: persistedToolState,
   },
-  middleware: getDefaultMiddleware => getDefaultMiddleware().concat(preferencesMiddleware),
+  middleware: getDefaultMiddleware =>
+    getDefaultMiddleware().concat(preferencesMiddleware, projectMiddleware),
 })
 
 export type RootState = ReturnType<typeof store.getState>

--- a/src/thunks/editingThunks.test.ts
+++ b/src/thunks/editingThunks.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { configureStore, combineReducers } from '@reduxjs/toolkit'
 import undoable from 'redux-undo'
 import notesReducer, { addNotes } from '@/store/slices/notesSlice'
+import projectReducer from '@/store/slices/projectSlice'
 import selectionReducer, { setSelection } from '@/store/slices/selectionSlice'
 import toolReducer from '@/store/slices/toolSlice'
 import transportReducer from '@/store/slices/transportSlice'
@@ -15,6 +16,7 @@ function makeStore () {
   return configureStore({
     reducer: combineReducers({
       notes:     undoable(notesReducer),
+      project:   projectReducer,
       selection: selectionReducer,
       tool:      toolReducer,
       transport: transportReducer,

--- a/src/thunks/projectThunks.test.ts
+++ b/src/thunks/projectThunks.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import undoable from 'redux-undo'
+import notesReducer, { addNotes } from '@/store/slices/notesSlice'
+import projectReducer from '@/store/slices/projectSlice'
+import selectionReducer, { setSelection } from '@/store/slices/selectionSlice'
+import toolReducer from '@/store/slices/toolSlice'
+import transportReducer from '@/store/slices/transportSlice'
+import viewportReducer from '@/store/slices/viewportSlice'
+import { selectAllNotes } from '@/store/selectors/noteSelectors'
+import { PPQ } from '@/domain/constants'
+import { ticksPerBar } from '@/domain/time'
+import type { Note } from '@/domain/types'
+import { encodeSmf } from '@/midi/smfEncode'
+import { importMidiData } from './projectThunks'
+
+
+function makeStore () {
+  return configureStore({
+    reducer: combineReducers({
+      notes:     undoable(notesReducer),
+      project:   projectReducer,
+      selection: selectionReducer,
+      tool:      toolReducer,
+      transport: transportReducer,
+      viewport:  viewportReducer,
+    }),
+  })
+}
+
+const fileNotes: Note[] = [
+  { id: 'x', pitch: 62, start: 0, duration: 480, velocity: 96 },
+  { id: 'y', pitch: 65, start: PPQ * 4, duration: PPQ, velocity: 80 }, // ends inside bar 2
+]
+
+describe('importMidiData', () => {
+  it('replaces the document with the parsed file contents', () => {
+    const store = makeStore()
+    store.dispatch(addNotes([{ id: 'old', pitch: 30, start: 0, duration: 100, velocity: 50 }]))
+    store.dispatch(setSelection([ 'old' ]))
+
+    const bytes = encodeSmf({
+      notes:         fileNotes,
+      bpm:           99,
+      timeSignature: { numerator: 6, denominator: 8 },
+      ppq:           PPQ,
+    })
+    store.dispatch(importMidiData(bytes, 'imported.mid'))
+
+    const state = store.getState()
+    const all   = selectAllNotes(state)
+
+    expect(all).toHaveLength(2)
+    expect(all.map(n => n.pitch).sort((a, b) => a - b)).toEqual([ 62, 65 ])
+    // Fresh ids are assigned on import.
+    expect(all.some(n => n.id === 'old')).toBe(false)
+
+    expect(state.transport.bpm).toBe(99)
+    expect(state.transport.timeSignature).toEqual({ numerator: 6, denominator: 8 })
+    expect(state.transport.isPlaying).toBe(false)
+    expect(state.transport.positionTicks).toBe(0)
+
+    expect(state.selection.selectedIds).toEqual([])
+    expect(state.project.fileName).toBe('imported.mid')
+    expect(state.project.dirty).toBe(false)
+    // A loaded file is a fresh undo baseline.
+    expect(state.notes.past).toHaveLength(0)
+  })
+
+  it('rounds the clip end up to a whole bar and matches the loop to it', () => {
+    const store = makeStore()
+    const bytes = encodeSmf({
+      notes:         fileNotes,
+      bpm:           120,
+      timeSignature: { numerator: 4, denominator: 4 },
+      ppq:           PPQ,
+    })
+    store.dispatch(importMidiData(bytes, 'clip.mid'))
+
+    const state = store.getState()
+    const bar   = ticksPerBar(state.transport.timeSignature)
+    // Last note ends at 5 quarters = 1.25 bars; clip end rounds up to 2 bars.
+    expect(state.transport.clipEndTicks).toBe(bar * 2)
+    expect(state.transport.loop).toMatchObject({ startTicks: 0, endTicks: bar * 2 })
+  })
+
+  it('throws on malformed data without touching the document', () => {
+    const store = makeStore()
+    store.dispatch(addNotes([{ id: 'keep', pitch: 60, start: 0, duration: 10, velocity: 100 }]))
+
+    expect(() => store.dispatch(importMidiData(new Uint8Array([ 9, 9, 9 ]), 'bad.mid'))).toThrow()
+    expect(selectAllNotes(store.getState()).map(n => n.id)).toEqual([ 'keep' ])
+  })
+})

--- a/src/thunks/projectThunks.ts
+++ b/src/thunks/projectThunks.ts
@@ -1,0 +1,110 @@
+import { nanoid } from '@reduxjs/toolkit'
+import { ActionCreators as UndoActions } from 'redux-undo'
+import type { AppDispatch, RootState } from '@/store/store'
+import { setAllNotes } from '@/store/slices/notesSlice'
+import { markClean, setFileName } from '@/store/slices/projectSlice'
+import { clearSelection } from '@/store/slices/selectionSlice'
+import {
+  seek,
+  setBpm,
+  setClipEnd,
+  setLoop,
+  setTimeSignature,
+  stop,
+} from '@/store/slices/transportSlice'
+import { setScroll } from '@/store/slices/viewportSlice'
+import { selectAllNotes } from '@/store/selectors/noteSelectors'
+import { PPQ } from '@/domain/constants'
+import { ticksPerBar } from '@/domain/time'
+import { encodeSmf } from '@/midi/smfEncode'
+import { parseSmf } from '@/midi/smfParse'
+
+
+type Thunk = (dispatch: AppDispatch, getState: () => RootState) => void
+
+const DEFAULT_FILE_NAME = 'untitled.mid'
+
+/** Last note end rounded up to a whole bar, minimum one bar. */
+type TimeSignatureType = { numerator: number; denominator: number }
+
+const clipEndForNotes = (
+  lastNoteEnd: number,
+  timeSignature: TimeSignatureType,
+): number => {
+  const bar = ticksPerBar(timeSignature)
+  return Math.max(1, Math.ceil(lastNoteEnd / bar)) * bar
+}
+
+/**
+ * Replace the document with the contents of a parsed MIDI file. Kept
+ * synchronous (bytes in) so it is unit-testable without File/Blob APIs.
+ */
+export const importMidiData = (bytes: Uint8Array, fileName: string): Thunk =>
+  (dispatch, getState) => {
+    const parsed = parseSmf(bytes, PPQ)
+
+    dispatch(stop())
+    dispatch(clearSelection())
+    dispatch(setAllNotes(parsed.notes.map(n => ({ ...n, id: nanoid() }))))
+
+    if (parsed.bpm !== undefined)
+      dispatch(setBpm(parsed.bpm))
+    if (parsed.timeSignature !== undefined)
+      dispatch(setTimeSignature(parsed.timeSignature))
+
+    const ts      = getState().transport.timeSignature
+    const lastEnd = parsed.notes.reduce((max, n) => Math.max(max, n.start + n.duration), 0)
+    const clipEnd = clipEndForNotes(lastEnd, ts)
+    dispatch(setClipEnd(clipEnd))
+    dispatch(setLoop({ startTicks: 0, endTicks: clipEnd }))
+    dispatch(seek(0))
+    // Bring the loaded content into view.
+    dispatch(setScroll({ scrollTicks: 0 }))
+
+    dispatch(setFileName(fileName))
+    // A loaded file is a fresh baseline: undoing into the previous document
+    // would desync the file name and dirty flag.
+    dispatch(UndoActions.clearHistory())
+    dispatch(markClean())
+  }
+
+/** Import a picked/dropped .mid file. */
+export const importMidiFile = (file: File): Thunk =>
+  dispatch => {
+    void file.arrayBuffer().then(buffer => {
+      try {
+        dispatch(importMidiData(new Uint8Array(buffer), file.name))
+      }
+      catch (err) {
+        console.error('MIDI import failed:', err)
+      }
+    })
+  }
+
+/** Serialize the document to SMF and trigger a browser download. */
+export const exportMidi = (): Thunk =>
+  (dispatch, getState) => {
+    const state = getState()
+    const bytes = encodeSmf({
+      notes:         selectAllNotes(state),
+      bpm:           state.transport.bpm,
+      timeSignature: state.transport.timeSignature,
+      ppq:           PPQ,
+    })
+
+    const fileName = state.project.fileName ?? DEFAULT_FILE_NAME
+    downloadBlob(bytes, fileName)
+
+    dispatch(setFileName(fileName))
+    dispatch(markClean())
+  }
+
+function downloadBlob (bytes: Uint8Array, fileName: string) {
+  const blob = new Blob([ bytes as BlobPart ], { type: 'audio/midi' })
+  const url  = URL.createObjectURL(blob)
+  const a    = document.createElement('a')
+  a.href     = url
+  a.download = fileName
+  a.click()
+  URL.revokeObjectURL(url)
+}

--- a/src/view/rulerHitTest.test.ts
+++ b/src/view/rulerHitTest.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import type { LoopRegion } from '@/domain/types'
+import type { Viewport } from './coords'
+import { rulerHitTest } from './rulerHitTest'
+
+
+// 1 px per tick with no scroll: tickToX(t) = keyboardWidth + t.
+const vp: Viewport = {
+  pxPerTick:     1,
+  rowHeight:     16,
+  scrollTicks:   0,
+  scrollPitch:   84,
+  width:         1000,
+  height:        600,
+  keyboardWidth: 64,
+  rulerHeight:   28,
+}
+
+const loop: LoopRegion = { enabled: true, startTicks: 100, endTicks: 300 }
+const clipEnd          = 500
+
+const braceY = 5 // inside the upper brace band (0..14)
+const seekY  = 20 // lower band
+
+describe('rulerHitTest', () => {
+  it('lower band always seeks, even at a loop edge x', () => {
+    expect(rulerHitTest(64 + 100, seekY, vp, loop, clipEnd, 'mouse').kind).toBe('seek')
+    expect(rulerHitTest(64 + 200, seekY, vp, loop, clipEnd, 'mouse').kind).toBe('seek')
+  })
+
+  it('hits loop edges within mouse tolerance', () => {
+    expect(rulerHitTest(64 + 104, braceY, vp, loop, clipEnd, 'mouse').kind).toBe('loop-start')
+    expect(rulerHitTest(64 + 296, braceY, vp, loop, clipEnd, 'mouse').kind).toBe('loop-end')
+  })
+
+  it('uses a wider tolerance for touch', () => {
+    expect(rulerHitTest(64 + 112, braceY, vp, loop, clipEnd, 'mouse').kind).toBe('loop-body')
+    expect(rulerHitTest(64 + 112, braceY, vp, loop, clipEnd, 'touch').kind).toBe('loop-start')
+  })
+
+  it('hits the loop body between the edges', () => {
+    expect(rulerHitTest(64 + 200, braceY, vp, loop, clipEnd, 'mouse').kind).toBe('loop-body')
+  })
+
+  it('prefers the nearer edge on a tiny loop', () => {
+    const tiny: LoopRegion = { enabled: true, startTicks: 100, endTicks: 106 }
+    expect(rulerHitTest(64 + 101, braceY, vp, tiny, clipEnd, 'mouse').kind).toBe('loop-start')
+    expect(rulerHitTest(64 + 105, braceY, vp, tiny, clipEnd, 'mouse').kind).toBe('loop-end')
+  })
+
+  it('hits the clip end marker', () => {
+    expect(rulerHitTest(64 + 500, braceY, vp, loop, clipEnd, 'mouse').kind).toBe('clip-end')
+  })
+
+  it('loop edge wins when the clip end marker overlaps it', () => {
+    expect(rulerHitTest(64 + 300, braceY, vp, loop, 300, 'mouse').kind).toBe('loop-end')
+  })
+
+  it('seeks in the brace band outside loop and markers', () => {
+    expect(rulerHitTest(64 + 420, braceY, vp, loop, clipEnd, 'mouse').kind).toBe('seek')
+  })
+})

--- a/src/view/rulerHitTest.ts
+++ b/src/view/rulerHitTest.ts
@@ -1,0 +1,47 @@
+// Pure hit-testing for the timeline ruler: loop brace, clip-end marker, seek.
+// The brace band is the upper half of the ruler; the lower half always seeks.
+
+import { RULER_EDGE_TOL_PX, RULER_EDGE_TOL_TOUCH_PX } from '@/domain/constants'
+import type { LoopRegion, Ticks } from '@/domain/types'
+import { tickToX } from './coords'
+import type { Viewport } from './coords'
+
+
+export type RulerHit =
+  | { kind: 'loop-start' } |
+  { kind: 'loop-end' } |
+  { kind: 'loop-body' } |
+  { kind: 'clip-end' } |
+  { kind: 'seek' }
+
+export const BRACE_BAND_RATIO = 0.5
+
+export function rulerHitTest (
+  px: number,
+  py: number,
+  vp: Viewport,
+  loop: LoopRegion,
+  clipEndTicks: Ticks,
+  pointerType: string,
+): RulerHit {
+  if (py >= vp.rulerHeight * BRACE_BAND_RATIO)
+    return { kind: 'seek' }
+
+  const tol       = pointerType === 'touch' ? RULER_EDGE_TOL_TOUCH_PX : RULER_EDGE_TOL_PX
+  const startX    = tickToX(loop.startTicks, vp)
+  const endX      = tickToX(loop.endTicks, vp)
+  const clipEndX  = tickToX(clipEndTicks, vp)
+  const distStart = Math.abs(px - startX)
+  const distEnd   = Math.abs(px - endX)
+
+  // Loop edges take priority; on a tiny loop prefer the nearer edge.
+  if (distStart <= tol && distStart <= distEnd)
+    return { kind: 'loop-start' }
+  if (distEnd <= tol)
+    return { kind: 'loop-end' }
+  if (Math.abs(px - clipEndX) <= tol)
+    return { kind: 'clip-end' }
+  if (px >= startX && px <= endX)
+    return { kind: 'loop-body' }
+  return { kind: 'seek' }
+}

--- a/src/view/theme.ts
+++ b/src/view/theme.ts
@@ -22,4 +22,9 @@ export const theme = {
   draftNote:     'rgba(255,209,102,0.5)',
   waveformFill:  'rgba(255,255,255,0.10)',
   waveformLine:  'rgba(255,255,255,0.55)',
+  loopBrace:     '#ffd166',
+  loopBraceDim:  'rgba(255,209,102,0.30)',
+  loopHandle:    '#ffe3a1',
+  clipEnd:       '#9aa0ad',
+  beyondClipEnd: 'rgba(0,0,0,0.28)',
 } as const


### PR DESCRIPTION
## Summary

Brings the piano roll to feature parity with an Ableton-style clip editor on both desktop and touch devices, and adds `.mid` save/load.

### Tools: select / draw / pan
- The marquee tool is merged into **select**: dragging empty space rubber-band selects (Shift = additive); clicking a note still moves/resizes it. A plain click on empty space clears the selection as before.

### Scroll zooming & wheel remap
- Plain wheel now **zooms horizontally at the cursor**; `Ctrl/Cmd+wheel` also zooms (this is what browsers synthesize for trackpad pinches), `Alt+wheel` zooms vertically, `Shift+wheel` pans, and dominant horizontal deltas pan the timeline (`interactions/wheelIntent.ts`).
- The wheel handler moved to a **native non-passive listener** — React's `onWheel` is passive, so the previous handler could not `preventDefault()` and `Ctrl+wheel` also zoomed the whole page.

### Full touch support
- New `usePianoRollInteractions` gesture router: routes pointers by region (ruler / keyboard / grid) and pointer count. One finger drives the active tool; a **second finger cancels the in-flight gesture and starts a pinch** — per-axis pinch zoom anchored at the finger centroid plus two-finger panning (pure math in `interactions/pinch.ts`, with dead zones and per-event clamps).
- Ruler markers use wider grab tolerances for coarse (touch) pointers.

### Loop indicator & clip end marker (Ableton-style)
- The ruler's upper band renders a **loop brace** (dimmed when looping is off) — drag the body to move it, the edges to resize it, all snapped to the grid.
- New **clip end marker** (`transport.clipEndTicks`), draggable in the ruler. When looping is off, **playback stops at the clip end** and returns to the start; the grid beyond the clip end is visually de-emphasized.
- The ruler's lower band now **seeks** (click or scrub-drag, snapped).

### MIDI save/load
- Hand-rolled SMF module in `src/midi/` — type-0 encoder, type-0/1 parser (running status, velocity-0 note-offs, PPQ rescaling, clear errors for format-2/SMPTE files) — behind pure functions that emit plain domain objects, per `docs/SPEC.md` §3.1.
- `projectSlice` (file name + dirty flag maintained by middleware), `importMidiData` / `importMidiFile` / `exportMidi` thunks. Import replaces the document, applies tempo/time signature, derives the clip end from the last note (rounded up to a bar), and resets the undo history.
- UI: toolbar Open/Save buttons with a file-name/dirty indicator, `Ctrl/Cmd+O` / `Ctrl/Cmd+S` shortcuts, and drag-and-drop of `.mid` files onto the window.

### Fixes found while verifying
- `zoomX`/`zoomY` now clamp scrolling the same way `panBy` does — zooming out near the origin no longer exposes negative bar numbers.
- Importing a file scrolls the view back to the origin so the loaded notes are visible.

## Testing

- 100 unit tests pass (34 new: wheel intent, pinch math, ruler hit zones, transport loop/clip-end invariants, VLQ + SMF encode/parse round-trips and malformed-file handling, project slice, import thunk).
- `npm run typecheck`, `npm run lint` (0 errors), `npm test`, `npm run build` all green locally.
- Verified end-to-end in headless Chromium (Playwright + CDP touch events): marquee select, wheel zoom, ruler seek/loop/clip-end drags, two-finger pinch zoom, export → download → re-import round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011m4Q2GWcfAzym2yrP7AbF8

---
_Generated by [Claude Code](https://claude.ai/code/session_011m4Q2GWcfAzym2yrP7AbF8)_